### PR TITLE
Allow url as input for bib

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,54 @@
+# HKPL Book Management System Documentation
+
+## System Overview
+Web-based tool for managing Hong Kong Public Library book availability across branches. Provides real-time updates and historical tracking of book copies.
+
+## Key Features
+```mermaid
+graph LR
+    A[User Interface] --> B(Book Search)
+    A --> C(Library Selection)
+    A --> D(Saved Books)
+    B --> E{Web Scraper}
+    C --> F[Availability Check]
+    D --> G[(Database)]
+```
+
+## Setup Guide
+1. **Prerequisites**:
+   - Python 3.8+
+   - `pip install -r requirements.txt`
+
+2. **Initialization**:
+   ```bash
+   python "create empty database.py"
+   flask run
+   ```
+
+## Usage Guide
+### Book Search
+1. Enter either:
+   - HKPL Bib ID (e.g. `3655993`)
+   - Full book URL from HKPL website
+2. View real-time availability across libraries
+
+### Library Management
+1. Select library branch from dropdown
+2. System displays:
+   - Available copies
+   - Last update timestamp
+   - Collection location
+
+## Troubleshooting
+| Error Message | Solution |
+|---------------|----------|
+| "Update failed" | Retry during off-peak hours |
+| "Invalid Bib ID" | Verify ID format: 7-digit number |
+| Scraping errors | Check HKPL website status |
+
+## FAQ
+**Q: How often is availability updated?**  
+A: Manual updates via "Update Copies" button
+
+**Q: Data storage location?**  
+A: SQLite database (`hkpl_tools.db`)

--- a/SEARCH_FEATURE_IMPLEMENTATION.md
+++ b/SEARCH_FEATURE_IMPLEMENTATION.md
@@ -1,0 +1,89 @@
+# HKPL Tools Search Feature Implementation Plan
+
+## Overview
+Implement a dedicated search page for book lookup functionality while maintaining existing save workflow.
+
+```mermaid
+sequenceDiagram
+    User->>Frontend: Clicks "Search Books" link
+    Frontend->>Backend: GET /search
+    Backend->>Frontend: Serve search.html
+    User->>Frontend: Enters search term
+    Frontend->>Backend: POST /search
+    Backend->>HKPL: Scrape results
+    HKPL-->>Backend: Return book data
+    Backend->>Frontend: Display results
+    User->>Frontend: Clicks "Save" on result
+    Frontend->>Backend: POST / with bib
+    Backend->>Database: Save book
+    Database-->>Frontend: Confirmation
+```
+
+## Implementation Details
+
+### 1. New Template (search.html)
+```html
+<!-- templates/search.html -->
+{% extends "base.html" %}
+
+{% block content %}
+  <form action="/search" method="post">
+    <input type="text" name="search_term" 
+           placeholder="Enter book title or author"
+           value="{{ search_term }}">
+    <button type="submit">Search</button>
+  </form>
+
+  {% if results %}
+  <div class="search-results">
+    {% for book in results %}
+    <div class="result-item">
+      <h3>{{ book.title }}</h3>
+      <p>Publication: {{ book.publication }}</p>
+      <form action="/" method="POST">
+        <input type="hidden" name="bib" value="{{ book.id }}">
+        <button type="submit">Save Book</button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endblock %}
+```
+
+### 2. Route Addition (app.py)
+```python
+@app.route("/search", methods=['GET', 'POST'])
+def search_books():
+    if request.method == 'POST':
+        search_term = request.form.get('search_term')
+        results = get_book_list(search_term)
+        return render_template('search.html',
+                            results=results,
+                            search_term=search_term,
+                            libraries=libraries)
+    return render_template('search.html', libraries=libraries)
+```
+
+### 3. Navigation Update
+```html
+<!-- In templates/index.html -->
+<div style="margin: 20px 0;">
+  <a href="/">Home</a> | 
+  <a href="/search">Search Books</a> | 
+  <a href="/Saved_Books">Saved Books</a>
+</div>
+```
+
+## Validation Checklist
+- [ ] Search page maintains consistent styling
+- [ ] Error handling for empty/invalid searches
+- [ ] Mobile-responsive layout
+- [ ] Proper navigation between pages
+- [ ] Existing save functionality unaffected
+
+## Next Steps
+1. Create search.html template
+2. Implement /search route
+3. Update navigation links
+4. Test search/save integration

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,69 @@
+# HKPL Tools User Guide
+
+## Application Workflow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant WebUI
+    participant Database
+    participant HKPLWebsite
+    
+    User->>WebUI: Enters BIB ID/URL
+    WebUI->>HKPLWebsite: Scrapes book data
+    HKPLWebsite-->>WebUI: Returns book details
+    WebUI->>Database: Stores book metadata
+    WebUI-->>User: Shows save confirmation
+    
+    User->>WebUI: Selects library
+    WebUI->>Database: Queries available copies
+    Database-->>WebUI: Returns availability data
+    WebUI-->>User: Displays library availability
+    
+    User->>WebUI: Clicks "Update Copies"
+    WebUI->>HKPLWebsite: Checks current status
+    HKPLWebsite-->>WebUI: Returns latest data
+    WebUI->>Database: Updates records
+    WebUI-->>User: Shows update status
+    
+    User->>WebUI: Views Saved Books
+    WebUI->>Database: Retrieves tracked books
+    Database-->>WebUI: Returns book list
+    WebUI-->>User: Displays management interface
+```
+
+## Core Features
+
+### 1. Book Tracking
+- **Supported Inputs**:
+  - Direct BIB numbers (e.g. 147569)
+  - HKPL website URLs
+- **Data Processing**:
+  - Automatic URL parsing
+  - Real-time availability checks
+  - Multi-library support
+
+### 2. Availability Monitoring
+- **Library Selection**:
+  - Dropdown with 20+ branches
+  - Last update timestamp
+- **Display Format**:
+  ```html
+  <table>
+    <tr>
+      <th>Title</th><th>Call No.</th>
+      <th>Status</th><th>Collection</th>
+    </tr>
+    <!-- Dynamic rows -->
+  </table>
+  ```
+
+### 3. Data Management
+- **Update System**:
+  - Manual trigger via UI
+  - Batch processing
+  - Error reporting
+- **Book Management**:
+  - Bulk delete interface
+  - Soft delete (planned)
+  - Version history (planned)

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from inserting_data_to_db import insertIntoTables, getCopies, updateCopies, last
 import datetime
 import logging
 from urllib.parse import urlparse, parse_qs
+from book_lookup import get_book_list
 
 app = Flask(__name__)
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
@@ -52,6 +53,37 @@ def home():
         print(e)
         logging.exception(e)
         return render_template('index.html', error_msg='An error occurred. Please try again.', libraries=libraries)
+
+@app.route('/search', methods=['GET', 'POST'])
+def search_books():
+    try:
+        if request.method == 'POST':
+            search_term = request.form.get('search_term')
+            if not search_term or search_term.strip() == '':
+                return render_template('search.html', 
+                                    error_msg='Please enter a search term',
+                                    libraries=libraries)
+            
+            results = get_book_list(search_term)
+            if isinstance(results, str):  # Error message from get_book_list
+                return render_template('search.html',
+                                    error_msg=results,
+                                    search_term=search_term,
+                                    libraries=libraries)
+            
+            return render_template('search.html',
+                                results=results,
+                                search_term=search_term,
+                                libraries=libraries)
+        
+        return render_template('search.html', libraries=libraries)
+    except Exception as e:
+        print(e)
+        logging.exception(e)
+        return render_template('search.html',
+                            error_msg='An error occurred during search. Please try again.',
+                            libraries=libraries)
+
 
 @app.route("/Saved_Books", methods=['GET','POST'])
 def savedBooks():

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request
 from inserting_data_to_db import insertIntoTables, getCopies, updateCopies, lastUpdate, getBookTable, listOfLibraries, delBook
 import datetime
 import logging
+from urllib.parse import urlparse, parse_qs
 
 app = Flask(__name__)
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
@@ -20,6 +21,14 @@ def home():
         if request.method == 'POST':
             if 'bib' in request.form:
                 bib = request.form['bib']
+                # Try Parse bib as URL
+                parsed_url = urlparse(bib)
+                query_params = parse_qs(parsed_url.query) # Extract the query string
+                id_value = query_params.get('id', [None])[0] # Get the 'id' parameter: should be in format "chamo:3655993"
+                id = id_value.split(':')[-1] if id_value else None # Extract the numeric part after the colon)
+                bib = id if id else bib # Use the extracted ID if available, otherwise use the original bib value
+                # End of parsing bib as URL
+                print(bib) # Print the final bib value to be used
                 message = insertIntoTables(bib)
                 return render_template('index.html',save_msg=f'{message}', lastupdate=get_last_update_text(lastupdate), libraries=libraries)
             elif 'library' in request.form: 

--- a/app.py
+++ b/app.py
@@ -8,27 +8,30 @@ app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 
 libraries = listOfLibraries()
 
+def get_last_update_text(lastupdate):
+    return f'Last Update: {lastupdate}'
+
 @app.route("/", methods=['POST', 'GET'])
 def home():
     try:
         lastupdate = lastUpdate()
         if request.method == 'GET':        
-            return render_template('index.html', lastupdate=f'Last Update: {lastupdate}', libraries=libraries)
+            return render_template('index.html', lastupdate=get_last_update_text(lastupdate), libraries=libraries)
         if request.method == 'POST':
             if 'bib' in request.form:
                 bib = request.form['bib']
                 message = insertIntoTables(bib)
-                return render_template('index.html',save_msg=f'{message}', lastupdate=f'Last Update: {lastupdate}', libraries=libraries)
+                return render_template('index.html',save_msg=f'{message}', lastupdate=get_last_update_text(lastupdate), libraries=libraries)
             elif 'library' in request.form: 
                 # if request.form['library'] == '':
-                #     return render_template('index.html', lastupdate=f'lastupdate: {lastupdate}', error_msg = 'please select a library', libraries=libraries)
+                #     return render_template('index.html', lastupdate=get_last_update_text(lastupdate), error_msg = 'please select a library', libraries=libraries)
                 library = request.form['library']
                 print(library)
                 copies = getCopies(library)
                 print('finish getCopies')
                 # print(copies)
                 library_msg = f'{len(copies)} copies available in {library} Library'
-                return render_template('index.html', copies=copies, library_msg=library_msg, lastupdate=f'Last Update: {lastupdate}', libraries=libraries, selection=library)
+                return render_template('index.html', copies=copies, library_msg=library_msg, lastupdate=get_last_update_text(lastupdate), libraries=libraries, selection=library)
             else:    #update
                 books_failed_to_update = updateCopies()
                 if books_failed_to_update == []:

--- a/app.py
+++ b/app.py
@@ -64,6 +64,9 @@ def savedBooks():
         delBook(book_ids)
         table = getBookTable()
         return render_template('books.html', column_names=table[0], books=table[1], msg=f'{book_ids} has been deleted')
+@app.route('/user_guide')
+def user_guide():
+    return render_template('user_guide.html')
 # @app.route("/Delete_Books", methods=['POST'])
 # def deleteBook():
 

--- a/book_lookup.py
+++ b/book_lookup.py
@@ -27,6 +27,12 @@ def get_book_list(search_term):
         if record_highlight:
             # Extract publication and call number
             item_fields = record_highlight.find('div', class_='itemFields')
+            
+            # Extract image URL
+            img_tag = record.find('div', class_='recordImage').find('img')
+            if img_tag and img_tag.get('src'):
+                book_info['image_url'] = img_tag['src']
+            
             if item_fields:
                 for row in item_fields.find_all('tr'):
                     label = row.find('td', class_='label')
@@ -42,7 +48,7 @@ def get_book_list(search_term):
                 # Extract ID from href
                 href = title.get('href')
                 if href:
-                    book_info['id'] = href.split('id=')[1].split('&')[0].split(':')[1] if 'id=' in href else None
+                    book_info['bib'] = href.split('id=')[1].split('&')[0].split(':')[1] if 'id=' in href else None
             
             if book_info:  # Only add if we have complete information
                 books.append(book_info)

--- a/book_lookup.py
+++ b/book_lookup.py
@@ -40,6 +40,15 @@ def get_book_list(search_term):
                         book_info['publication'] = label.find_next_sibling('td').text.strip()
                     if label and label.text.strip() == 'Call Number':
                         book_info['call_number'] = label.find_next_sibling('td').text.strip()
+
+            # Extract availability
+            availability = record.find('span', class_='availabilityTotal')
+            if availability:
+                availability_text = availability.text.strip()
+                try:
+                    book_info['available_copies'] = int(availability_text.split()[0])
+                except (ValueError, IndexError):
+                    book_info['available_copies'] = 0
             
             # Extract title and ID
             title = record_highlight.find('a', class_='title')

--- a/book_lookup.py
+++ b/book_lookup.py
@@ -1,0 +1,56 @@
+import urllib.request
+from bs4 import BeautifulSoup
+import urllib.parse
+
+url_template = 'https://webcat.hkpl.gov.hk/search/query?term_1={search_term}&theme=WEB&locale=en'
+
+def get_search_url(search_term):
+    return url_template.format(search_term=urllib.parse.quote(search_term))
+
+def get_book_list(search_term):
+    url = get_search_url(search_term)
+    try:
+        response = urllib.request.urlopen(urllib.request.Request(url,headers={'User-Agent': 'Mozilla/5.0'}))
+    except urllib.request.HTTPError as e:
+        print(e)
+        return f'Error. "{url}" cannot be reached. Check hkpl web or bib exist.'
+
+    htmlbytes = response.read()
+    bs = BeautifulSoup(htmlbytes, "html.parser")
+    books = []
+    
+    # Extract book information
+    records = bs.find_all('li', class_='record')
+    for record in records:
+        book_info = {}
+        record_highlight = record.find('div', class_='recordHighlight')
+        if record_highlight:
+            # Extract publication and call number
+            item_fields = record_highlight.find('div', class_='itemFields')
+            if item_fields:
+                for row in item_fields.find_all('tr'):
+                    label = row.find('td', class_='label')
+                    if label and label.text.strip() == 'Publication':
+                        book_info['publication'] = label.find_next_sibling('td').text.strip()
+                    if label and label.text.strip() == 'Call Number':
+                        book_info['call_number'] = label.find_next_sibling('td').text.strip()
+            
+            # Extract title and ID
+            title = record_highlight.find('a', class_='title')
+            if title:
+                book_info['title'] = title.text.strip()
+                # Extract ID from href
+                href = title.get('href')
+                if href:
+                    book_info['id'] = href.split('id=')[1].split('&')[0].split(':')[1] if 'id=' in href else None
+            
+            if book_info:  # Only add if we have complete information
+                books.append(book_info)
+            
+    # write bs.contents to file
+    with open('output.html', 'w', encoding='utf-8') as f:
+        f.write(str(bs.contents))# print(bs.prettify())  # This will print the prettified HTML to the console
+    # You can also write the prettified HTML to a file if needed
+    with open('output_prettified.html', 'w', encoding='utf-8') as f:
+        f.write(bs.prettify())  # This will write the prettified HTML to a file
+    return books

--- a/inserting_data_to_db.py
+++ b/inserting_data_to_db.py
@@ -1,5 +1,5 @@
 import sqlite3
-from beautifulsoup_testing import get_info
+from beautifulsoup import get_info
     
 def insertIntoTables(bib):
     info = get_info(bib)

--- a/inserting_data_to_db.py
+++ b/inserting_data_to_db.py
@@ -176,10 +176,10 @@ def listOfLibraries():
         sqliteConnection = sqlite3.connect('hkpl_tools.db')
         cursor = sqliteConnection.cursor()
         print("Connected to SQLite: getting list of libraries")
-        cursor.execute("SELECT englishName from Library ORDER BY libraryID ASC")
+        cursor.execute("SELECT englishName, libraryNumber from Library ORDER BY libraryID ASC")
         results = cursor.fetchall()
         # print(results)
-        libraries = [result[0] for result in results]
+        libraries = [{'englishName': result[0], 'libraryNumber': result[1]} for result in results]
         return libraries
     except sqlite3.Error as error:
         print('**************failed to get list of libraries', error,'**************************')

--- a/output.html
+++ b/output.html
@@ -1,0 +1,1392 @@
+['\n', 'html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"\n  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"', '\n', <html dir="ltr" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head><script src="../wicket/resource/org.apache.wicket.resource.JQueryResourceReference/jquery/jquery-1.11.3.min-ver-2C872DBE60F4BA70FB85356113D8B35E.js" type="text/javascript"></script>
+<script src="../wicket/resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-event-jquery.min-ver-CD167ED7BEFC26AED029F20C2EBF9AA7.js" type="text/javascript"></script>
+<script src="../wicket/resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-ajax-jquery.min-ver-373007567CBDD4D664471DD5DBA38759.js" type="text/javascript"></script>
+<script id="wicket-ajax-base-url" type="text/javascript">
+/*<![CDATA[*/
+Wicket.Ajax.baseUrl="search/query?term_1=%E5%AD%94%E5%AD%90&amp;locale=en&amp;theme=WEB";
+/*]]>*/
+</script>
+<script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/jquery-ui-1.11.4.custom.min-ver-3305041B1DFFC2ADA01DD1F54417F300.js" type="text/javascript"></script>
+<script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/jquery.cookie-ver-FAC04835FF4A7B4A029C7B7E91E7B750.js" type="text/javascript"></script>
+<script src="../wicket/resource/com.vtls.chamo.webapp.behavior.ShowMoreBehavior/showmore-ver-43114D8F1E889F1F49486B8E5DD995AB.js" type="text/javascript"></script>
+<script src="../wicket/resource/com.vtls.chamo.webapp.component.LocaleDropDown/addUrlParam-ver-82B221D975654586499AB8BB24645506.js" type="text/javascript"></script>
+<script id="selectedLocaleVariable" type="text/javascript">
+/*<![CDATA[*/
+var selectedLocale;
+/*]]>*/
+</script>
+<script src="../wicket/resource/org.apache.wicket.extensions.ajax.markup.html.autocomplete.AutoCompleteBehavior/wicket-autocomplete.min-ver-9FB11C2AC0FBDE36252E50E13C8A305E.js" type="text/javascript"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+Wicket.Event.add(window, "domready", function(event) { new Wicket.AutoComplete('idd','../wicket/page?0-1.IBehaviorListener.0-search-quickSearch-form-query&theme=WEB',{preselect: false,maxHeight: -1,adjustInputWidth: true,useSmartPositioning: false,useHideShowCoveredIEFix: true,showListOnEmptyInput: false,ignoreBordersWhenPositioning: true,showListOnFocusGain: false,throttleDelay: 300,minInputLength: 1,parameterName: 'q',showCompleteListOnFocusGain: false},null);;});
+/*]]>*/
+</script>
+<script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/jquery.ui.notify-ver-E3FE61789842CE600350E76CBF7A6E72.js" type="text/javascript"></script>
+<script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/toastfeedback-ver-6DD0FBB6003393FF17A8553B005FFAB9.js" type="text/javascript"></script>
+<!-- HTTP 1.1 -->
+<meta content="no-store" http-equiv="Cache-Control"/>
+<!-- HTTP 1.0 -->
+<meta content="no-cache" http-equiv="Pragma"/>
+<!-- Prevents caching at the Proxy Server -->
+<meta content="0" http-equiv="Expires"/>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+<meta content="900;url=../auth/logout?url=/%3Ftheme%3DWEB&amp;theme=WEB&amp;locale=en" http-equiv="Refresh"/>
+<title>Search | Chamo</title>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/favicon-ver-4543EFC9ECCA2647A9527AF5AC4D0ADD.ico?en-WEB" rel="shortcut icon"/>
+<!-- TODO should be dyn. links -->
+<link href="../scripts/dojo/dijit/themes/dijit.css" rel="stylesheet" type="text/css"/>
+<link href="../scripts/dojo/dijit/themes/tundra/tundra.css" rel="stylesheet" type="text/css"/>
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-42372800-1']);
+  _gaq.push(['_trackPageview', '/OpacSearchPage' + window.location.search]);
+
+  (function() {
+    var ga = document.createElement('script');
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.setAttribute('async', 'true');
+    document.documentElement.firstChild.appendChild(ga);
+  })();
+</script>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/jquery-ui-1.11.4.custom-ver-DB2BA219F9AD80A302AE31C8965CFD97.css?en-WEB" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/jquery.minicolors-ver-ABC741231BB83BCCD431A18824551815.css?en-WEB" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/jquery.ui.notify-ver-0FACCFE6FA1D01367E823F14512835DF.css?en-WEB" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/theme-ver-6474BE8E760F428BF54B31A2438804A5.css?en-WEB" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/theme-override-ver-F88FE9652BBA464E22F6F2FBD1A9D2AF.css?en-WEB" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/print-ver-8DC1AB4A50408BAD7D2ED6314A916A4A.css?en-WEB" media="print" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.BaseApplication/colors.css?en-WEB" rel="stylesheet" type="text/css"/>
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/webkit-fix-ver-47C63E6E600866370BA50AC7B4488FE2.css?en-WEB" rel="stylesheet" type="text/css"/>
+<!--[if IE]><link rel="stylesheet" type="text/css" href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/ie-fix-ver-4C4FBCD8C6201838023ADDE843026797.css?en-WEB" /><![endif]-->
+<script type="text/javascript">
+/*<![CDATA[*/
+Wicket.Event.add(window, "domready", function(event) { 
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-topCartButtons-addToCart&theme=WEB","e":"click","c":"id1"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-0-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id2"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-1-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id3"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-2-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id4"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-3-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id5"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-4-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id6"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-5-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id7"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-6-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id8"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-7-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id9"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-8-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"ida"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-9-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"idb"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-bottomCartButtons-addToCart&theme=WEB","e":"click","c":"idc"});;
+Wicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);
+;});
+/*]]>*/
+</script>
+<script type="text/javascript">
+/*<![CDATA[*/
+Wicket.Event.add(window, "load", function(event) { 
+document.getElementById('search-sort-submit').style.visibility='hidden';;
+$('form').not('.nonRefreshing').submit(function() {   if (this.beenSubmitted)     return false;   else     this.beenSubmitted = true; }); 
+;
+;});
+/*]]>*/
+</script>
+</head>
+<body class="tundra">
+<div id="page">
+<div class="clearfix" id="header">
+<link href="../wicket/resource/com.vtls.chamo.webapp.application.help.HelpFile/css/custom_en.css" media="all" rel="stylesheet" type="text/css"/>
+<div id="branding">
+<!--
+    <div class="logo">
+      <a wicket:id="logoLink" href="#"><img wicket:id="logo" src="#" alt="logo" /></a>
+    </div>
+    -->
+<div class="siteNameDisplay">
+<a href="..?theme=WEB">
+<span>Chamo</span>
+</a>
+</div>
+</div>
+<div class="helpLink">
+<a href="../wicket/resource/com.vtls.chamo.webapp.application.help.HelpFile/OpacSearchPage-ver-652C3BECE4A4A2F0C4A52E01D26DF723.htm" id="helpLink" onclick="var w = window.open(href, '', 'scrollbars=yes,location=yes,menuBar=no,resizable=yes,status=no,toolbar=no,width=500,height=550'); try {if (w.blur) w.focus();}catch(ignore){}; return false; javascript: _gaq.push(['_trackPageView', '/help/OpacSearchPage.htm'])">
+<img alt="Help" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/help-ver-FB084FC152CD51E4CFAD79C8FFE48D40.png?en-WEB"/>
+</a>
+</div>
+<div id="locale">
+<select id="languageSelect" name="header:locale:languageSelect" onchange="window.location.search=addUrlParam(window.location.search, 'locale', this.options[selectedIndex].value)">
+<option selected="selected" value="en">英文</option>
+<option value="zh_TW">中文(繁體)</option>
+</select>
+</div>
+<div class="hanWebLink">
+<a href="../wicket/page?0-1.ILinkListener-header-hanWebLinkContainer-hanWebLink&amp;theme=WEB" id="hanWebLink" onclick="var conf = confirm('Changing languages will result in a loss of your session.  Are you sure you wish to continue?'); if (!conf) { Wicket.Event.stop(event, true);  event.stopImmediatePropagation();  return false; } ">中文(简体)</a>
+</div>
+<script src="../wicket/resource/com.vtls.chamo.webapp.application.help.HelpFile/js/custom.js?en" type="text/javascript"></script>
+</div>
+<div class="clearfix" id="content">
+<div id="nav">
+<div class="wrapper">
+<ul class="menuList" id="primary-nav">
+<li><a href="../auth/login?theme=WEB&amp;locale=en"><span>Login</span></a></li><li><a href="../wicket/bookmarkable/com.vtls.chamo.webapp.component.listcart.OpacCartPage?theme=WEB"><span>Cart</span></a></li><li><a href="../heading/search?theme=WEB"><span>Heading Search</span></a></li><li><a href="./history?theme=WEB"><span>Search History</span></a></li><li></li><li><a href="../auth/clearsession?theme=WEB"><span>Clear Session</span></a></li>
+</ul>
+<div class="mobileLink">
+<a href="?theme=mobile">Mobile</a>
+</div>
+<br class="clear-both"/>
+</div>
+</div>
+<div id="search">
+<div class="quicksearch-panel">
+<form action="../wicket/page?0-1.IFormSubmitListener-search-quickSearch-form&amp;theme=WEB" id="ide" method="post"><div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden"><input id="ide_hf_0" name="ide_hf_0" type="hidden"/></div>
+<div class="quicksearch-panel">
+<input autocomplete="off" id="idd" maxlength="250" name="query" placeholder="Search" size="50" type="text" value="孔子"/>
+<div class="advancedSearchLink"><a href="./advanced?theme=WEB" id="advancedSearchLink">Advanced Search</a></div>
+</div>
+<div class="quicksearch-panel">
+<input class="button" type="submit" value="Search"/>
+</div>
+</form>
+</div>
+</div>
+<div id="feedback">
+</div><div id="toastFeedback">
+<div id="toastFeedback" style="display:none">
+<div class="feedback" id="feedback-template">
+<ul class="feedbackPanel">
+<li class="mainFeedbackPanel#{level}">
+<a class="ui-notify-cross ui-notify-close" href="#">x</a>
+<span class="mainFeedbackPanel#{level}">#{text}</span>
+</li>
+</ul>
+</div>
+</div>
+</div><script type="text/javascript">
+/*<![CDATA[*/
+$('#toastFeedback').notify();
+toastFeedback($('#feedback'), $('#toastFeedback'), {INFO:0,WARNING:0,ERROR:0,UNDEFINED:0})
+/*]]>*/
+</script>
+<div id="main">
+<div class="federatedSearch">
+</div>
+<div class="searchInfo list" id="currentSearchBlock">
+<div id="searchTerms">
+<div id="currentSearchLabel">
+        Current Search:
+      </div>
+<ul>
+<li>
+<span class="searchValue">
+<span title="孔子">孔子</span>
+</span>
+<a href="./query?sort=relevance&amp;theme=WEB"><img alt="X" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/remove-ver-61889DEE564F8F9A66A0E54407F9D269.png?en-WEB"/></a>
+</li>
+</ul>
+</div>
+</div>
+<div class="list" id="list">
+<div id="searchNavBar">
+<div id="sortResultControls">
+<form action="../wicket/page?0-1.IFormSubmitListener-results-sortPanel-sortForm&amp;theme=WEB" id="idf" method="post"><div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden"><input id="idf_hf_0" name="idf_hf_0" type="hidden"/></div>
+<div>
+<label for="search_sort">Sort by</label>
+<select id="search_sort" name="sortChoice" onchange="document.getElementById('idf_hf_0').value='./page?0-1.IOnChangeListener-results-sortPanel-sortForm-sortChoice&amp;theme=WEB';document.getElementById('idf').submit();">
+<option value="0">Recently added items first</option>
+<option selected="selected" value="1">Relevance</option>
+<option value="2">Author</option>
+<option value="3">Title</option>
+<option value="4">Publishing Date (Oldest First)</option>
+<option value="5">Publishing Date (Newest First)</option>
+</select>
+<input class="button" id="search-sort-submit" name="search-sort-submit" type="submit" value="Sort"/>
+</div>
+</form>
+</div>
+<div class="resultCount">
+<span>Results 1 to 10 of 1543</span>
+</div>
+<div class="addThis">
+<!-- Update for Google Analytics 4, on 1-Aug-2023 -->
+<!-- Google tag (gtag.js) -->
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-XNTC90BNSE"></script>
+<script> 
+  window.dataLayer = window.dataLayer || []; 
+  function gtag(){dataLayer.push(arguments);} 
+  gtag('js', new Date()); 
+
+  gtag('config', 'G-XNTC90BNSE'); 
+</script>
+</div>
+<div id="syndication">
+<a href="./syndication?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;syndication=true&amp;theme=WEB">
+<img alt="xml" height="16" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/syndicationFeedIcon-ver-A09C57F60463DB4D8545801926D659E7.png?en-WEB" width="16"/>
+</a>
+</div>
+</div>
+<form action="../wicket/page?0-1.IFormSubmitListener-results-resultListForm&amp;theme=WEB" id="itemlist" method="post"><div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden"><input id="itemlist_hf_0" name="itemlist_hf_0" type="hidden"/></div>
+<div class="clear"></div>
+<span>
+<div>
+<div class="buttons">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-topCartButtons-addToCart&amp;theme=WEB" id="id1">Select Page</a>
+</div>
+</div>
+<ul class="records">
+<li class="record">
+<div class="recordNumber">
+<div>
+                  1.
+                </div>
+<div class="recordImage" data-isbn="9787805188935" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:2529957&amp;fromLocationLink=false&amp;theme=WEB">論語 / 孔子弟子錄編.</a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">杭州 : 浙江古籍, 2004.</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">097.1 0000</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id10">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id10'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-0-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-0-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id2">Add To Cart</a>
+<a id="id11" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  2.
+                </div>
+<div class="recordImage" data-isbn="9787805688671" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:1463598&amp;fromLocationLink=false&amp;theme=WEB">孔子聖蹟圖.</a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">北京 : 中國書店, 1998.</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">121.23 1116</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id12">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id12'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-1-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-1-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id3">Add To Cart</a>
+<a id="id13" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  3.
+                </div>
+<div class="recordImage" data-isbn="" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:77996&amp;fromLocationLink=false&amp;theme=WEB">孔子思想研究文集 / 山西省孔子學術研究會編.</a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">太原 : 山西人民, 1988.</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">121.237 1164</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id14">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id14'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-2-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-2-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id4">Add To Cart</a>
+<a id="id15" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  4.
+                </div>
+<div class="recordImage" data-isbn="9787212015633" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:2063278&amp;fromLocationLink=false&amp;theme=WEB">孔子本紀 孔子百問 / 孔祥驊, 孔正毅著.</a>
+<a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E5%AD%94%E7%A5%A5%E9%A9%8A+1941-++&amp;theme=WEB">孔祥驊 1941-  </a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">合肥 : 安徽人民, 2001.</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">121.23 1237</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id16">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id16'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-3-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-3-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id5">Add To Cart</a>
+<a id="id17" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  5.
+                </div>
+<div class="recordImage" data-isbn="9787542605146" data-oclc="">
+<img alt="cover image" src="http://books.google.com/books/content?id=9aENAQAAMAAJ&amp;printsec=frontcover&amp;img=1&amp;zoom=5&amp;source=gbs_api"/>
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:211298&amp;fromLocationLink=false&amp;theme=WEB">孔子誕辰2540周年紀念與學術討論會論文集. : 上 / 中國孔子基金會編.</a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">上海 : 三聯, 1992.</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id18">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id18'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-4-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-4-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id6">Add To Cart</a>
+<a id="id19" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  6.
+                </div>
+<div class="recordImage" data-isbn="9787542605146" data-oclc="">
+<img alt="cover image" src="http://books.google.com/books/content?id=9aENAQAAMAAJ&amp;printsec=frontcover&amp;img=1&amp;zoom=5&amp;source=gbs_api"/>
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:211299&amp;fromLocationLink=false&amp;theme=WEB">孔子誕辰2540周年紀念與學術討論會論文集. : 中 / 中國孔子基金會編.</a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">上海 : 三聯, 1992.</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id1a">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id1a'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-5-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-5-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id7">Add To Cart</a>
+<a id="id1b" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  7.
+                </div>
+<div class="recordImage" data-isbn="9787542605146" data-oclc="">
+<img alt="cover image" src="http://books.google.com/books/content?id=9aENAQAAMAAJ&amp;printsec=frontcover&amp;img=1&amp;zoom=5&amp;source=gbs_api"/>
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:211300&amp;fromLocationLink=false&amp;theme=WEB">孔子誕辰2540周年紀念與學術討論會論文集. : 下 / 中國孔子基金會編.</a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">上海 : 三聯, 1992.</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id1c">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id1c'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-6-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-6-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id8">Add To Cart</a>
+<a id="id1d" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  8.
+                </div>
+<div class="recordImage" data-isbn="" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:2713371&amp;fromLocationLink=false&amp;theme=WEB">孔子孝經 / [孔子著 ; 閻敏之講]</a>
+<a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E5%AD%94%E5%AD%90+%E5%85%AC%E5%85%83%E5%89%8D551-479++&amp;theme=WEB">孔子 公元前551-479  </a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">[台北 : 王氏圖書館, 19--?]</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">096.2 1217</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id1e">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id1e'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-7-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-7-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id9">Add To Cart</a>
+<a id="id1f" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  9.
+                </div>
+<div class="recordImage" data-isbn="9787532518289" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:1196357&amp;fromLocationLink=false&amp;theme=WEB">孔子語錄 / [孔子原著] ; 張榮華編譯.</a>
+<a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E5%AD%94%E5%AD%90+%E5%85%AC%E5%85%83%E5%89%8D551-479++&amp;theme=WEB">孔子 公元前551-479  </a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">上海 : 上海古籍, 1994.</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">121.23 1108</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">No lending copy is available on shelf now</span>
+<ul class="locationAvailability" id="id20">
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id20'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-8-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-8-searchRecord-recordCart-addToCart&amp;theme=WEB" id="ida">Add To Cart</a>
+<a id="id21" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li><li class="record">
+<div class="recordNumber">
+<div>
+                  10.
+                </div>
+<div class="recordImage" data-isbn="9787515325118" data-oclc="">
+</div>
+<div class="formatImage">
+<img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+</div>
+</div>
+<div class="record">
+<div class="recordHighlight">
+<a class="title" dir="ltr" href="../lib/item?id=chamo:3677805&amp;fromLocationLink=false&amp;theme=WEB">孔子原來 : 被誤解的孔子 / 鮑鵬山著.</a>
+<a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E9%AE%91%E9%B5%AC%E5%B1%B1+1963-++&amp;theme=WEB">鮑鵬山 1963-  </a>
+<div class="itemSearchResultFields">
+<div class="itemFields">
+<table>
+<tr>
+<td class="label" dir="ltr">Publication</td>
+<td><div><span dir="ltr">北京 : 中國青年出版社, 2020.</span></div></td>
+</tr><tr>
+<td class="label" dir="ltr">Call Number</td>
+<td><div><span dir="ltr">121.23 2772</span></div></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="search-availability">
+<span class="availabilityTotal">6 lending copies are available on shelf at</span>
+<ul class="locationAvailability" id="id22">
+<li class="locationAvailability">
+<a href="#"><span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">26. Ngau Tau Kok</span></a>
+<span class="availabilityCount" dir="ltr">(1 available)</span>
+</li><li class="locationAvailability">
+<a href="#"><span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">34. Quarry Bay</span></a>
+<span class="availabilityCount" dir="ltr">(1 available)</span>
+</li><li class="locationAvailability">
+<a href="#"><span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">40. Sham Shui Po</span></a>
+<span class="availabilityCount" dir="ltr">(1 available)</span>
+</li><li class="locationAvailability">
+<a href="#"><span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">62. Tsuen Wan</span></a>
+<span class="availabilityCount" dir="ltr">(1 available)</span>
+</li><li class="locationAvailability">
+<a href="#"><span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">68. Yau Ma Tei</span></a>
+<span class="availabilityCount" dir="ltr">(1 available)</span>
+</li><li class="locationAvailability">
+<a href="#"><span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">70. Yuen Chau Kok</span></a>
+<span class="availabilityCount" dir="ltr">(1 available)</span>
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id22'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</div>
+<div class="request-item">
+<span class="requestCount" dir="ltr">0 reservation made for this item.</span>
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-9-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">Reserve</a>
+</div>
+<div class="recordCart">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-9-searchRecord-recordCart-addToCart&amp;theme=WEB" id="idb">Add To Cart</a>
+<a id="id23" style="display:none"></a>
+</div>
+</div>
+<div class="recordSeparator"> </div>
+</li>
+</ul>
+<div>
+<div class="buttons">
+<a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-bottomCartButtons-addToCart&amp;theme=WEB" id="idc">Select Page</a>
+</div>
+</div>
+</span>
+</form>
+<div class="bottomNavBar">
+<div class="pageLinks">
+<span><span>1</span></span>
+<span> | </span>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=2&amp;theme=WEB"><span>2</span></a>
+<span> | </span>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=3&amp;theme=WEB"><span>3</span></a>
+<span> | </span>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=4&amp;theme=WEB"><span>4</span></a>
+<span> | </span>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=2&amp;theme=WEB"><span>Next &gt;</span></a>
+</div>
+<div>
+<label for="search-pagesize">Results per page</label>
+<select class="inline select" id="search-pagesize" name="results:pageSizeSelector:search-pagesize" onchange="window.location.href='../wicket/page?0-1.IOnChangeListener-results-pageSizeSelector-search~pagesize&amp;theme=WEB&amp;results:pageSizeSelector:search-pagesize=' + this.options[this.selectedIndex].value;">
+<option value="5">5</option>
+<option selected="selected" value="10">10</option>
+<option value="20">20</option>
+<option value="30">30</option>
+<option value="40">40</option>
+<option value="50">50</option>
+</select>
+</div>
+</div>
+</div>
+<div class="sidebar" id="refine">
+<div class="header">
+        Refine your search
+      </div>
+<div id="additional-search-terms">
+<form action="../wicket/page?0-1.IFormSubmitListener-facets-additionalTermsForm&amp;theme=WEB" id="id24" method="post"><div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden"><input id="id24_hf_0" name="id24_hf_0" type="hidden"/></div>
+<div>
+<label for="additional-terms">Additional Terms</label>
+<input id="additional-terms" maxlength="250" name="additionalTerms" type="text" value=""/>
+<input class="button" id="add-additional-terms" type="submit" value="Add"/>
+</div>
+</form>
+</div>
+<ul>
+<li>
+<span class="facetField" dir="ltr">Publication Year</span>
+<ul id="id25"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.202&amp;sort=relevance&amp;theme=WEB">2020 - 2029</a> (<span class="facetCount">58</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.201&amp;sort=relevance&amp;theme=WEB">2010 - 2019</a> (<span class="facetCount">211</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.200&amp;sort=relevance&amp;theme=WEB">2000 - 2009</a> (<span class="facetCount">418</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.199&amp;sort=relevance&amp;theme=WEB">1990 - 1999</a> (<span class="facetCount">336</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.198&amp;sort=relevance&amp;theme=WEB">1980 - 1989</a> (<span class="facetCount">124</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.197&amp;sort=relevance&amp;theme=WEB">1970 - 1979</a> (<span class="facetCount">69</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.196&amp;sort=relevance&amp;theme=WEB">1960 - 1969</a> (<span class="facetCount">53</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.195&amp;sort=relevance&amp;theme=WEB">1950 - 1959</a> (<span class="facetCount">15</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.194&amp;sort=relevance&amp;theme=WEB">1940 - 1949</a> (<span class="facetCount">3</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.193&amp;sort=relevance&amp;theme=WEB">1930 - 1939</a> (<span class="facetCount">48</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.192&amp;sort=relevance&amp;theme=WEB">1920 - 1929</a> (<span class="facetCount">12</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.191&amp;sort=relevance&amp;theme=WEB">1910 - 1919</a> (<span class="facetCount">6</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.190&amp;sort=relevance&amp;theme=WEB">1900 - 1909</a> (<span class="facetCount">11</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.189&amp;sort=relevance&amp;theme=WEB">1890 - 1899</a> (<span class="facetCount">9</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.188&amp;sort=relevance&amp;theme=WEB">1880 - 1889</a> (<span class="facetCount">5</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.187&amp;sort=relevance&amp;theme=WEB">1870 - 1879</a> (<span class="facetCount">11</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.184&amp;sort=relevance&amp;theme=WEB">1840 - 1849</a> (<span class="facetCount">16</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.167&amp;sort=relevance&amp;theme=WEB">1670 - 1679</a> (<span class="facetCount">1</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id25'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li><li>
+<span class="facetField" dir="ltr">Language</span>
+<ul id="id26"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=chi&amp;sort=relevance&amp;theme=WEB">Chinese</a> (<span class="facetCount">1534</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=eng&amp;sort=relevance&amp;theme=WEB">English</a> (<span class="facetCount">5</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=jpn&amp;sort=relevance&amp;theme=WEB">Japanese</a> (<span class="facetCount">1</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=mul&amp;sort=relevance&amp;theme=WEB">Multiple languages</a> (<span class="facetCount">1</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id26'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li><li>
+<span class="facetField" dir="ltr">Place of Publication</span>
+<ul id="id27"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=cc&amp;sort=relevance&amp;theme=WEB">China</a> (<span class="facetCount">951</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=ch&amp;sort=relevance&amp;theme=WEB">Taiwan</a> (<span class="facetCount">268</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=cch&amp;sort=relevance&amp;theme=WEB">Hong Kong</a> (<span class="facetCount">217</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=xx&amp;sort=relevance&amp;theme=WEB">No place / unknown</a> (<span class="facetCount">91</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=si&amp;sort=relevance&amp;theme=WEB">Singapore</a> (<span class="facetCount">7</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=bcc&amp;sort=relevance&amp;theme=WEB">British Columbia</a> (<span class="facetCount">4</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=ja&amp;sort=relevance&amp;theme=WEB">Japan</a> (<span class="facetCount">2</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=dcu&amp;sort=relevance&amp;theme=WEB">District of Columbia</a> (<span class="facetCount">1</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=my&amp;sort=relevance&amp;theme=WEB">Malaysia</a> (<span class="facetCount">1</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id27'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li><li>
+<span class="facetField" dir="ltr">Library</span>
+<ul id="id28"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=501000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">01. Aberdeen</span></a> (<span class="facetCount">64</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=701000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">02. Ap Lei Chau</span></a> (<span class="facetCount">23</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=702000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">03. Butterfly Estate</span></a> (<span class="facetCount">12</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=502000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">04. Chai Wan</span></a> (<span class="facetCount">86</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=503000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">05. Cheung Chau</span></a> (<span class="facetCount">31</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=301000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">06. City Hall</span></a> (<span class="facetCount">178</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=703000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">07. Electric Road</span></a> (<span class="facetCount">18</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=504000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">08. Fa Yuen Street</span></a> (<span class="facetCount">50</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=505000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">09. Fanling</span></a> (<span class="facetCount">120</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904340000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">10. Fanling South</span></a> (<span class="facetCount">27</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=704000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">11. Fu Shan</span></a> (<span class="facetCount">29</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=1000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">12. Hong Kong Central</span></a> (<span class="facetCount">1345</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904090000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">12. Hong Kong Central (Arts Resource Centre)</span></a> (<span class="facetCount">46</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=705000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">13. Hung Hom</span></a> (<span class="facetCount">23</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=302000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">14. Kowloon</span></a> (<span class="facetCount">368</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=706000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">15. Kowloon City</span></a> (<span class="facetCount">25</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=506000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">16. Lai Chi Kok</span></a> (<span class="facetCount">71</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=707000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">17. Lam Tin</span></a> (<span class="facetCount">102</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=708000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">18. Lei Yue Mun</span></a> (<span class="facetCount">29</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=709000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">19. Lek Yuen</span></a> (<span class="facetCount">16</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=507000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">20. Lockhart Road</span></a> (<span class="facetCount">77</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=710000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">21. Lok Fu</span></a> (<span class="facetCount">29</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=711000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">22. Lung Hing</span></a> (<span class="facetCount">17</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=508000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">23. Ma On Shan</span></a> (<span class="facetCount">71</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=712000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">24. Mui Wo</span></a> (<span class="facetCount">2</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=509000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">25. Ngau Chi Wan</span></a> (<span class="facetCount">54</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=510000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">26. Ngau Tau Kok</span></a> (<span class="facetCount">59</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=511000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">27. North Kwai Chung</span></a> (<span class="facetCount">68</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=713000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">28. North Lamma</span></a> (<span class="facetCount">7</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=512000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">29. North Point</span></a> (<span class="facetCount">27</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=715000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">30. Peng Chau</span></a> (<span class="facetCount">5</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904220000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">31. Ping Shan Tin Shui Wai </span></a> (<span class="facetCount">242</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=513000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">32. Po On Road</span></a> (<span class="facetCount">52</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=716000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">33. Pok Fu Lam</span></a> (<span class="facetCount">19</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=514000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">34. Quarry Bay</span></a> (<span class="facetCount">68</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=515000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">35. Sai Kung</span></a> (<span class="facetCount">29</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=516000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">36. San Po Kong</span></a> (<span class="facetCount">76</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=717000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">37. Sau Mau Ping</span></a> (<span class="facetCount">17</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=718000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">38. Sha Tau Kok</span></a> (<span class="facetCount">3</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=303000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">39. Sha Tin</span></a> (<span class="facetCount">196</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904360000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">40. Sham Shui Po</span></a> (<span class="facetCount">56</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=714000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">41. Shek Kip Mei</span></a> (<span class="facetCount">35</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=517000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">42. Shek Tong Tsui</span></a> (<span class="facetCount">67</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=719000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">43. Shek Wai Kok</span></a> (<span class="facetCount">21</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=518000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">44. Sheung Shui</span></a> (<span class="facetCount">79</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=519000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">45. Shui Wo Street</span></a> (<span class="facetCount">70</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=720000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">46. Shun Lee Estate</span></a> (<span class="facetCount">15</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904170000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">47. Siu Sai Wan</span></a> (<span class="facetCount">26</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=721000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">48. Smithfield</span></a> (<span class="facetCount">30</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=520000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">49. South Kwai Chung</span></a> (<span class="facetCount">71</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=722000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">50. South Lamma</span></a> (<span class="facetCount">2</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=723000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">51. Stanley</span></a> (<span class="facetCount">23</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=521000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">52. Tai Hing</span></a> (<span class="facetCount">35</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=724000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">53. Tai Kok Tsui</span></a> (<span class="facetCount">22</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=725000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">54. Tai O</span></a> (<span class="facetCount">3</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=522000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">55. Tai Po</span></a> (<span class="facetCount">100</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=726000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">56. Tin Shui Wai North</span></a> (<span class="facetCount">19</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904200000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">57. Tiu Keng Leng</span></a> (<span class="facetCount">99</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=524000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">58. To Kwa Wan</span></a> (<span class="facetCount">64</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=525000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">59. Tseung Kwan O</span></a> (<span class="facetCount">106</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=727000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">60. Tsim Sha Tsui</span></a> (<span class="facetCount">21</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=526000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">61. Tsing Yi</span></a> (<span class="facetCount">76</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=304000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">62. Tsuen Wan</span></a> (<span class="facetCount">254</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=728000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">63. Tsz Wan Shan</span></a> (<span class="facetCount">25</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=305000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">64. Tuen Mun</span></a> (<span class="facetCount">197</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=729000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">65. Tung Chung</span></a> (<span class="facetCount">105</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=730000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">66. Un Chau Street</span></a> (<span class="facetCount">21</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=731000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">67. Wong Nai Chung</span></a> (<span class="facetCount">20</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=527000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">68. Yau Ma Tei</span></a> (<span class="facetCount">45</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=732000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">69. Yiu Tung</span></a> (<span class="facetCount">18</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904300000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">70. Yuen Chau Kok</span></a> (<span class="facetCount">81</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=528000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">71. Yuen Long</span></a> (<span class="facetCount">65</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=901000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">72. Mobile Library 1</span></a> (<span class="facetCount">10</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=902000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">73. Mobile Library 2</span></a> (<span class="facetCount">8</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=903000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">74. Mobile Library 3/10</span></a> (<span class="facetCount">19</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904000000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">75. Mobile Library 4</span></a> (<span class="facetCount">10</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=901020000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">76. Mobile Library 5</span></a> (<span class="facetCount">7</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904040000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">77. Mobile Library 6/9</span></a> (<span class="facetCount">18</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904050000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">78. Mobile Library 7</span></a> (<span class="facetCount">14</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904060000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">79. Mobile Library 8</span></a> (<span class="facetCount">10</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904310000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">80. Mobile Library 11</span></a> (<span class="facetCount">11</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904320000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">81. Mobile Library 12</span></a> (<span class="facetCount">7</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904380000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">82. Self-service Library Station (Island East Sports Centre Sitting-out Area)</span></a> (<span class="facetCount">5</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904400000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">83. Self-service Library Station (Hong Kong Cultural Centre)</span></a> (<span class="facetCount">3</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904410000&amp;sort=relevance&amp;theme=WEB"><img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+<span class="multiselect-inactive">84. Self-service Library Station (Tsuen Nam Road, Tai Wai)</span></a> (<span class="facetCount">3</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id28'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li><li>
+<span class="facetField" dir="ltr">Format</span>
+<ul id="id29"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=book&amp;sort=relevance&amp;theme=WEB">Book</a> (<span class="facetCount">1399</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=movies&amp;sort=relevance&amp;theme=WEB">Visual Materials</a> (<span class="facetCount">79</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=sound_recording&amp;sort=relevance&amp;theme=WEB">Sound Recording</a> (<span class="facetCount">54</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=movies.dvd&amp;sort=relevance&amp;theme=WEB">DVD</a> (<span class="facetCount">44</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=sound_recording.audiobook&amp;sort=relevance&amp;theme=WEB">Audio Book</a> (<span class="facetCount">42</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=movies.vhs&amp;sort=relevance&amp;theme=WEB">VHS</a> (<span class="facetCount">34</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=sound_recording.cd&amp;sort=relevance&amp;theme=WEB">CD</a> (<span class="facetCount">7</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=Map&amp;sort=relevance&amp;theme=WEB">Map</a> (<span class="facetCount">4</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=computer_games&amp;sort=relevance&amp;theme=WEB">Computer Software</a> (<span class="facetCount">2</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=serial&amp;sort=relevance&amp;theme=WEB">Serial</a> (<span class="facetCount">2</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id29'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li><li>
+<span class="facetField" dir="ltr">Item Class</span>
+<ul id="id2a"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=32&amp;sort=relevance&amp;theme=WEB">Reference Materials</a> (<span class="facetCount">1212</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=3&amp;sort=relevance&amp;theme=WEB">Adult Lending Books</a> (<span class="facetCount">613</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=11&amp;sort=relevance&amp;theme=WEB">Junior Lending Books</a> (<span class="facetCount">84</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=19&amp;sort=relevance&amp;theme=WEB">Mobile Adult Lending Books</a> (<span class="facetCount">20</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=26&amp;sort=relevance&amp;theme=WEB">Mobile Junior Lending Books</a> (<span class="facetCount">20</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=7&amp;sort=relevance&amp;theme=WEB">Adult Lending Non-Book Materials</a> (<span class="facetCount">17</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=2&amp;sort=relevance&amp;theme=WEB">Adult Lending Accompanying Materials</a> (<span class="facetCount">5</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=15&amp;sort=relevance&amp;theme=WEB">Junior Lending Non-book Materials</a> (<span class="facetCount">3</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=10&amp;sort=relevance&amp;theme=WEB">Junior Lending Accompanying Materials</a> (<span class="facetCount">1</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=22&amp;sort=relevance&amp;theme=WEB">Mobile Adult Lending Non-Book Materials</a> (<span class="facetCount">1</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=25&amp;sort=relevance&amp;theme=WEB">Mobile Junior Lending Accompanying Materials</a> (<span class="facetCount">1</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id2a'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li><li>
+<span class="facetField" dir="ltr">Average Rating</span>
+<ul id="id2b"><li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=5&amp;sort=relevance&amp;theme=WEB"><img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_5-ver-D2BF8E75D0FBAFB8966709BBB65CB79C.png?en-WEB"/></a> (<span class="facetCount">35</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=4&amp;sort=relevance&amp;theme=WEB"><img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_4-ver-546323FD7198BCCFF3F8E4D1BF5E6B18.png?en-WEB"/></a> (<span class="facetCount">11</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=3&amp;sort=relevance&amp;theme=WEB"><img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_3-ver-53545B8190EE5E2F4227D38CB81D647D.png?en-WEB"/></a> (<span class="facetCount">2</span>)
+</li>
+<li>
+<a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=1&amp;sort=relevance&amp;theme=WEB"><img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_1-ver-A4817BFA47BE370F3D9A08C59698E035.png?en-WEB"/></a> (<span class="facetCount">2</span>)
+</li>
+</ul><script type="text/javascript">
+/*<![CDATA[*/
+showMoreInitialize($('#id2b'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+</script>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="clearfix" id="footer">
+<style>
+/*<![CDATA[*/
+
+#footerLink:hover{
+        color: #FFFF00 !important;
+        background:none !important;
+}
+
+/*]]>*/
+</style>
+<div id="divider"> </div>
+<span class="left">
+<span id="version">Version 3.5</span>
+</span>
+<span>  
+    <!--<a id="footerLink" href="http://10.47.243.52/misc/ngils/best_view/best_view_en.htm" style="color:white;text-decoration:underline;" onclick="window.open(this.href, '關於圖書館目錄',
+'left=20,top=20,width=800,height=270,toolbar=1,resizable=0'); return false;">-->
+<!--<a id="footerLink" href="http://cslinux0.comp.hkbu.edu.hk/~e2402184/best_view_en.htm" style="color:white;text-decoration:underline;" 
+			onclick="window.open(this.href, '關於圖書館目錄','left=20,top=20,width=400,height=200,toolbar=1,resizable=0'); return false;">-->
+<script type="text/javascript">
+/*<![CDATA[*/
+
+		var url=window.location.toString();
+		var link1="";
+
+		if (url.indexOf("TuniS")!=-1)
+		{
+			link1 = "http://www.hkpl.gov.hk/misc/ngils/best_view_sc.htm";
+		}
+		else
+		{
+			link1 = "http://www.hkpl.gov.hk/misc/ngils/best_view_en.htm";
+		}
+		var finalLink = "<a id=\"footerLink\" href=\""+link1+"\" style=\"color:white;text-decoration:underline;\" "+
+			"onclick=\"window.open(this.href, \'關於圖書館目錄\',\'left=20,top=20,width=400,height=200,toolbar=1,resizable=0\'); return false;\">About Library Catalogue</a>";
+		//document.write(finalLink);
+		
+/*]]>*/
+</script>
+</span>
+<span class="right">
+    © 2008-2011 <a>VTLS</a>
+</span>
+</div>
+</div>
+</body>
+</html>]

--- a/output_prettified.html
+++ b/output_prettified.html
@@ -1,0 +1,3074 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html dir="ltr" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <script src="../wicket/resource/org.apache.wicket.resource.JQueryResourceReference/jquery/jquery-1.11.3.min-ver-2C872DBE60F4BA70FB85356113D8B35E.js" type="text/javascript">
+  </script>
+  <script src="../wicket/resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-event-jquery.min-ver-CD167ED7BEFC26AED029F20C2EBF9AA7.js" type="text/javascript">
+  </script>
+  <script src="../wicket/resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-ajax-jquery.min-ver-373007567CBDD4D664471DD5DBA38759.js" type="text/javascript">
+  </script>
+  <script id="wicket-ajax-base-url" type="text/javascript">
+   /*<![CDATA[*/
+Wicket.Ajax.baseUrl="search/query?term_1=%E5%AD%94%E5%AD%90&amp;locale=en&amp;theme=WEB";
+/*]]>*/
+  </script>
+  <script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/jquery-ui-1.11.4.custom.min-ver-3305041B1DFFC2ADA01DD1F54417F300.js" type="text/javascript">
+  </script>
+  <script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/jquery.cookie-ver-FAC04835FF4A7B4A029C7B7E91E7B750.js" type="text/javascript">
+  </script>
+  <script src="../wicket/resource/com.vtls.chamo.webapp.behavior.ShowMoreBehavior/showmore-ver-43114D8F1E889F1F49486B8E5DD995AB.js" type="text/javascript">
+  </script>
+  <script src="../wicket/resource/com.vtls.chamo.webapp.component.LocaleDropDown/addUrlParam-ver-82B221D975654586499AB8BB24645506.js" type="text/javascript">
+  </script>
+  <script id="selectedLocaleVariable" type="text/javascript">
+   /*<![CDATA[*/
+var selectedLocale;
+/*]]>*/
+  </script>
+  <script src="../wicket/resource/org.apache.wicket.extensions.ajax.markup.html.autocomplete.AutoCompleteBehavior/wicket-autocomplete.min-ver-9FB11C2AC0FBDE36252E50E13C8A305E.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   /*<![CDATA[*/
+Wicket.Event.add(window, "domready", function(event) { new Wicket.AutoComplete('idd','../wicket/page?0-1.IBehaviorListener.0-search-quickSearch-form-query&theme=WEB',{preselect: false,maxHeight: -1,adjustInputWidth: true,useSmartPositioning: false,useHideShowCoveredIEFix: true,showListOnEmptyInput: false,ignoreBordersWhenPositioning: true,showListOnFocusGain: false,throttleDelay: 300,minInputLength: 1,parameterName: 'q',showCompleteListOnFocusGain: false},null);;});
+/*]]>*/
+  </script>
+  <script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/jquery.ui.notify-ver-E3FE61789842CE600350E76CBF7A6E72.js" type="text/javascript">
+  </script>
+  <script src="../wicket/resource/com.vtls.chamo.webapp.behavior.JQueryBehavior/toastfeedback-ver-6DD0FBB6003393FF17A8553B005FFAB9.js" type="text/javascript">
+  </script>
+  <!-- HTTP 1.1 -->
+  <meta content="no-store" http-equiv="Cache-Control"/>
+  <!-- HTTP 1.0 -->
+  <meta content="no-cache" http-equiv="Pragma"/>
+  <!-- Prevents caching at the Proxy Server -->
+  <meta content="0" http-equiv="Expires"/>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <meta content="900;url=../auth/logout?url=/%3Ftheme%3DWEB&amp;theme=WEB&amp;locale=en" http-equiv="Refresh"/>
+  <title>
+   Search | Chamo
+  </title>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/favicon-ver-4543EFC9ECCA2647A9527AF5AC4D0ADD.ico?en-WEB" rel="shortcut icon"/>
+  <!-- TODO should be dyn. links -->
+  <link href="../scripts/dojo/dijit/themes/dijit.css" rel="stylesheet" type="text/css"/>
+  <link href="../scripts/dojo/dijit/themes/tundra/tundra.css" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-42372800-1']);
+  _gaq.push(['_trackPageview', '/OpacSearchPage' + window.location.search]);
+
+  (function() {
+    var ga = document.createElement('script');
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.setAttribute('async', 'true');
+    document.documentElement.firstChild.appendChild(ga);
+  })();
+  </script>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/jquery-ui-1.11.4.custom-ver-DB2BA219F9AD80A302AE31C8965CFD97.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/jquery.minicolors-ver-ABC741231BB83BCCD431A18824551815.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/jquery.ui.notify-ver-0FACCFE6FA1D01367E823F14512835DF.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/theme-ver-6474BE8E760F428BF54B31A2438804A5.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/theme-override-ver-F88FE9652BBA464E22F6F2FBD1A9D2AF.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/print-ver-8DC1AB4A50408BAD7D2ED6314A916A4A.css?en-WEB" media="print" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.BaseApplication/colors.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <link href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/webkit-fix-ver-47C63E6E600866370BA50AC7B4488FE2.css?en-WEB" rel="stylesheet" type="text/css"/>
+  <!--[if IE]><link rel="stylesheet" type="text/css" href="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/ie-fix-ver-4C4FBCD8C6201838023ADDE843026797.css?en-WEB" /><![endif]-->
+  <script type="text/javascript">
+   /*<![CDATA[*/
+Wicket.Event.add(window, "domready", function(event) { 
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-topCartButtons-addToCart&theme=WEB","e":"click","c":"id1"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-0-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id2"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-1-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id3"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-2-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id4"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-3-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id5"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-4-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id6"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-5-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id7"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-6-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id8"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-7-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"id9"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-8-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"ida"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-searchResults-9-searchRecord-recordCart-addToCart&theme=WEB","e":"click","c":"idb"});;
+Wicket.Ajax.ajax({"u":"../wicket/page?0-1.IBehaviorListener.0-results-resultListForm-listItems-bottomCartButtons-addToCart&theme=WEB","e":"click","c":"idc"});;
+Wicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);
+;});
+/*]]>*/
+  </script>
+  <script type="text/javascript">
+   /*<![CDATA[*/
+Wicket.Event.add(window, "load", function(event) { 
+document.getElementById('search-sort-submit').style.visibility='hidden';;
+$('form').not('.nonRefreshing').submit(function() {   if (this.beenSubmitted)     return false;   else     this.beenSubmitted = true; }); 
+;
+;});
+/*]]>*/
+  </script>
+ </head>
+ <body class="tundra">
+  <div id="page">
+   <div class="clearfix" id="header">
+    <link href="../wicket/resource/com.vtls.chamo.webapp.application.help.HelpFile/css/custom_en.css" media="all" rel="stylesheet" type="text/css"/>
+    <div id="branding">
+     <!--
+    <div class="logo">
+      <a wicket:id="logoLink" href="#"><img wicket:id="logo" src="#" alt="logo" /></a>
+    </div>
+    -->
+     <div class="siteNameDisplay">
+      <a href="..?theme=WEB">
+       <span>
+        Chamo
+       </span>
+      </a>
+     </div>
+    </div>
+    <div class="helpLink">
+     <a href="../wicket/resource/com.vtls.chamo.webapp.application.help.HelpFile/OpacSearchPage-ver-652C3BECE4A4A2F0C4A52E01D26DF723.htm" id="helpLink" onclick="var w = window.open(href, '', 'scrollbars=yes,location=yes,menuBar=no,resizable=yes,status=no,toolbar=no,width=500,height=550'); try {if (w.blur) w.focus();}catch(ignore){}; return false; javascript: _gaq.push(['_trackPageView', '/help/OpacSearchPage.htm'])">
+      <img alt="Help" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/help-ver-FB084FC152CD51E4CFAD79C8FFE48D40.png?en-WEB"/>
+     </a>
+    </div>
+    <div id="locale">
+     <select id="languageSelect" name="header:locale:languageSelect" onchange="window.location.search=addUrlParam(window.location.search, 'locale', this.options[selectedIndex].value)">
+      <option selected="selected" value="en">
+       英文
+      </option>
+      <option value="zh_TW">
+       中文(繁體)
+      </option>
+     </select>
+    </div>
+    <div class="hanWebLink">
+     <a href="../wicket/page?0-1.ILinkListener-header-hanWebLinkContainer-hanWebLink&amp;theme=WEB" id="hanWebLink" onclick="var conf = confirm('Changing languages will result in a loss of your session.  Are you sure you wish to continue?'); if (!conf) { Wicket.Event.stop(event, true);  event.stopImmediatePropagation();  return false; } ">
+      中文(简体)
+     </a>
+    </div>
+    <script src="../wicket/resource/com.vtls.chamo.webapp.application.help.HelpFile/js/custom.js?en" type="text/javascript">
+    </script>
+   </div>
+   <div class="clearfix" id="content">
+    <div id="nav">
+     <div class="wrapper">
+      <ul class="menuList" id="primary-nav">
+       <li>
+        <a href="../auth/login?theme=WEB&amp;locale=en">
+         <span>
+          Login
+         </span>
+        </a>
+       </li>
+       <li>
+        <a href="../wicket/bookmarkable/com.vtls.chamo.webapp.component.listcart.OpacCartPage?theme=WEB">
+         <span>
+          Cart
+         </span>
+        </a>
+       </li>
+       <li>
+        <a href="../heading/search?theme=WEB">
+         <span>
+          Heading Search
+         </span>
+        </a>
+       </li>
+       <li>
+        <a href="./history?theme=WEB">
+         <span>
+          Search History
+         </span>
+        </a>
+       </li>
+       <li>
+       </li>
+       <li>
+        <a href="../auth/clearsession?theme=WEB">
+         <span>
+          Clear Session
+         </span>
+        </a>
+       </li>
+      </ul>
+      <div class="mobileLink">
+       <a href="?theme=mobile">
+        Mobile
+       </a>
+      </div>
+      <br class="clear-both"/>
+     </div>
+    </div>
+    <div id="search">
+     <div class="quicksearch-panel">
+      <form action="../wicket/page?0-1.IFormSubmitListener-search-quickSearch-form&amp;theme=WEB" id="ide" method="post">
+       <div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden">
+        <input id="ide_hf_0" name="ide_hf_0" type="hidden"/>
+       </div>
+       <div class="quicksearch-panel">
+        <input autocomplete="off" id="idd" maxlength="250" name="query" placeholder="Search" size="50" type="text" value="孔子"/>
+        <div class="advancedSearchLink">
+         <a href="./advanced?theme=WEB" id="advancedSearchLink">
+          Advanced Search
+         </a>
+        </div>
+       </div>
+       <div class="quicksearch-panel">
+        <input class="button" type="submit" value="Search"/>
+       </div>
+      </form>
+     </div>
+    </div>
+    <div id="feedback">
+    </div>
+    <div id="toastFeedback">
+     <div id="toastFeedback" style="display:none">
+      <div class="feedback" id="feedback-template">
+       <ul class="feedbackPanel">
+        <li class="mainFeedbackPanel#{level}">
+         <a class="ui-notify-cross ui-notify-close" href="#">
+          x
+         </a>
+         <span class="mainFeedbackPanel#{level}">
+          #{text}
+         </span>
+        </li>
+       </ul>
+      </div>
+     </div>
+    </div>
+    <script type="text/javascript">
+     /*<![CDATA[*/
+$('#toastFeedback').notify();
+toastFeedback($('#feedback'), $('#toastFeedback'), {INFO:0,WARNING:0,ERROR:0,UNDEFINED:0})
+/*]]>*/
+    </script>
+    <div id="main">
+     <div class="federatedSearch">
+     </div>
+     <div class="searchInfo list" id="currentSearchBlock">
+      <div id="searchTerms">
+       <div id="currentSearchLabel">
+        Current Search:
+       </div>
+       <ul>
+        <li>
+         <span class="searchValue">
+          <span title="孔子">
+           孔子
+          </span>
+         </span>
+         <a href="./query?sort=relevance&amp;theme=WEB">
+          <img alt="X" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/remove-ver-61889DEE564F8F9A66A0E54407F9D269.png?en-WEB"/>
+         </a>
+        </li>
+       </ul>
+      </div>
+     </div>
+     <div class="list" id="list">
+      <div id="searchNavBar">
+       <div id="sortResultControls">
+        <form action="../wicket/page?0-1.IFormSubmitListener-results-sortPanel-sortForm&amp;theme=WEB" id="idf" method="post">
+         <div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden">
+          <input id="idf_hf_0" name="idf_hf_0" type="hidden"/>
+         </div>
+         <div>
+          <label for="search_sort">
+           Sort by
+          </label>
+          <select id="search_sort" name="sortChoice" onchange="document.getElementById('idf_hf_0').value='./page?0-1.IOnChangeListener-results-sortPanel-sortForm-sortChoice&amp;theme=WEB';document.getElementById('idf').submit();">
+           <option value="0">
+            Recently added items first
+           </option>
+           <option selected="selected" value="1">
+            Relevance
+           </option>
+           <option value="2">
+            Author
+           </option>
+           <option value="3">
+            Title
+           </option>
+           <option value="4">
+            Publishing Date (Oldest First)
+           </option>
+           <option value="5">
+            Publishing Date (Newest First)
+           </option>
+          </select>
+          <input class="button" id="search-sort-submit" name="search-sort-submit" type="submit" value="Sort"/>
+         </div>
+        </form>
+       </div>
+       <div class="resultCount">
+        <span>
+         Results 1 to 10 of 1543
+        </span>
+       </div>
+       <div class="addThis">
+        <!-- Update for Google Analytics 4, on 1-Aug-2023 -->
+        <!-- Google tag (gtag.js) -->
+        <script async="" src="https://www.googletagmanager.com/gtag/js?id=G-XNTC90BNSE">
+        </script>
+        <script>
+         window.dataLayer = window.dataLayer || []; 
+  function gtag(){dataLayer.push(arguments);} 
+  gtag('js', new Date()); 
+
+  gtag('config', 'G-XNTC90BNSE');
+        </script>
+       </div>
+       <div id="syndication">
+        <a href="./syndication?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;syndication=true&amp;theme=WEB">
+         <img alt="xml" height="16" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/syndicationFeedIcon-ver-A09C57F60463DB4D8545801926D659E7.png?en-WEB" width="16"/>
+        </a>
+       </div>
+      </div>
+      <form action="../wicket/page?0-1.IFormSubmitListener-results-resultListForm&amp;theme=WEB" id="itemlist" method="post">
+       <div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden">
+        <input id="itemlist_hf_0" name="itemlist_hf_0" type="hidden"/>
+       </div>
+       <div class="clear">
+       </div>
+       <span>
+        <div>
+         <div class="buttons">
+          <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-topCartButtons-addToCart&amp;theme=WEB" id="id1">
+           Select Page
+          </a>
+         </div>
+        </div>
+        <ul class="records">
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            1.
+           </div>
+           <div class="recordImage" data-isbn="9787805188935" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:2529957&amp;fromLocationLink=false&amp;theme=WEB">
+             論語 / 孔子弟子錄編.
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   杭州 : 浙江古籍, 2004.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   097.1 0000
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id10">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id10'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-0-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-0-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id2">
+             Add To Cart
+            </a>
+            <a id="id11" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            2.
+           </div>
+           <div class="recordImage" data-isbn="9787805688671" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:1463598&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子聖蹟圖.
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   北京 : 中國書店, 1998.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   121.23 1116
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id12">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id12'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-1-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-1-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id3">
+             Add To Cart
+            </a>
+            <a id="id13" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            3.
+           </div>
+           <div class="recordImage" data-isbn="" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:77996&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子思想研究文集 / 山西省孔子學術研究會編.
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   太原 : 山西人民, 1988.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   121.237 1164
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id14">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id14'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-2-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-2-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id4">
+             Add To Cart
+            </a>
+            <a id="id15" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            4.
+           </div>
+           <div class="recordImage" data-isbn="9787212015633" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:2063278&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子本紀 孔子百問 / 孔祥驊, 孔正毅著.
+            </a>
+            <a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E5%AD%94%E7%A5%A5%E9%A9%8A+1941-++&amp;theme=WEB">
+             孔祥驊 1941-
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   合肥 : 安徽人民, 2001.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   121.23 1237
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id16">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id16'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-3-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-3-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id5">
+             Add To Cart
+            </a>
+            <a id="id17" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            5.
+           </div>
+           <div class="recordImage" data-isbn="9787542605146" data-oclc="">
+            <img alt="cover image" src="http://books.google.com/books/content?id=9aENAQAAMAAJ&amp;printsec=frontcover&amp;img=1&amp;zoom=5&amp;source=gbs_api"/>
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:211298&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子誕辰2540周年紀念與學術討論會論文集. : 上 / 中國孔子基金會編.
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   上海 : 三聯, 1992.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id18">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id18'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-4-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-4-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id6">
+             Add To Cart
+            </a>
+            <a id="id19" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            6.
+           </div>
+           <div class="recordImage" data-isbn="9787542605146" data-oclc="">
+            <img alt="cover image" src="http://books.google.com/books/content?id=9aENAQAAMAAJ&amp;printsec=frontcover&amp;img=1&amp;zoom=5&amp;source=gbs_api"/>
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:211299&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子誕辰2540周年紀念與學術討論會論文集. : 中 / 中國孔子基金會編.
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   上海 : 三聯, 1992.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id1a">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id1a'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-5-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-5-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id7">
+             Add To Cart
+            </a>
+            <a id="id1b" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            7.
+           </div>
+           <div class="recordImage" data-isbn="9787542605146" data-oclc="">
+            <img alt="cover image" src="http://books.google.com/books/content?id=9aENAQAAMAAJ&amp;printsec=frontcover&amp;img=1&amp;zoom=5&amp;source=gbs_api"/>
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:211300&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子誕辰2540周年紀念與學術討論會論文集. : 下 / 中國孔子基金會編.
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   上海 : 三聯, 1992.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id1c">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id1c'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-6-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-6-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id8">
+             Add To Cart
+            </a>
+            <a id="id1d" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            8.
+           </div>
+           <div class="recordImage" data-isbn="" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:2713371&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子孝經 / [孔子著 ; 閻敏之講]
+            </a>
+            <a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E5%AD%94%E5%AD%90+%E5%85%AC%E5%85%83%E5%89%8D551-479++&amp;theme=WEB">
+             孔子 公元前551-479
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   [台北 : 王氏圖書館, 19--?]
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   096.2 1217
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id1e">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id1e'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-7-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-7-searchRecord-recordCart-addToCart&amp;theme=WEB" id="id9">
+             Add To Cart
+            </a>
+            <a id="id1f" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            9.
+           </div>
+           <div class="recordImage" data-isbn="9787532518289" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:1196357&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子語錄 / [孔子原著] ; 張榮華編譯.
+            </a>
+            <a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E5%AD%94%E5%AD%90+%E5%85%AC%E5%85%83%E5%89%8D551-479++&amp;theme=WEB">
+             孔子 公元前551-479
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   上海 : 上海古籍, 1994.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   121.23 1108
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             No lending copy is available on shelf now
+            </span>
+            <ul class="locationAvailability" id="id20">
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id20'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-8-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-8-searchRecord-recordCart-addToCart&amp;theme=WEB" id="ida">
+             Add To Cart
+            </a>
+            <a id="id21" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+         <li class="record">
+          <div class="recordNumber">
+           <div>
+            10.
+           </div>
+           <div class="recordImage" data-isbn="9787515325118" data-oclc="">
+           </div>
+           <div class="formatImage">
+            <img alt="book" class="icon" height="16" src="../wicket/resource/com.vtls.chamo.webapp.component.opac.search.FormatIcon/book.gif" width="22"/>
+           </div>
+          </div>
+          <div class="record">
+           <div class="recordHighlight">
+            <a class="title" dir="ltr" href="../lib/item?id=chamo:3677805&amp;fromLocationLink=false&amp;theme=WEB">
+             孔子原來 : 被誤解的孔子 / 鮑鵬山著.
+            </a>
+            <a class="author" dir="ltr" href="./query?match_1=PHRASE&amp;field_1=a&amp;term_1=%E9%AE%91%E9%B5%AC%E5%B1%B1+1963-++&amp;theme=WEB">
+             鮑鵬山 1963-
+            </a>
+            <div class="itemSearchResultFields">
+             <div class="itemFields">
+              <table>
+               <tr>
+                <td class="label" dir="ltr">
+                 Publication
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   北京 : 中國青年出版社, 2020.
+                  </span>
+                 </div>
+                </td>
+               </tr>
+               <tr>
+                <td class="label" dir="ltr">
+                 Call Number
+                </td>
+                <td>
+                 <div>
+                  <span dir="ltr">
+                   121.23 2772
+                  </span>
+                 </div>
+                </td>
+               </tr>
+              </table>
+             </div>
+            </div>
+           </div>
+           <div class="search-availability">
+            <span class="availabilityTotal">
+             6 lending copies are available on shelf at
+            </span>
+            <ul class="locationAvailability" id="id22">
+             <li class="locationAvailability">
+              <a href="#">
+               <span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">
+                26. Ngau Tau Kok
+               </span>
+              </a>
+              <span class="availabilityCount" dir="ltr">
+               (1 available)
+              </span>
+             </li>
+             <li class="locationAvailability">
+              <a href="#">
+               <span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">
+                34. Quarry Bay
+               </span>
+              </a>
+              <span class="availabilityCount" dir="ltr">
+               (1 available)
+              </span>
+             </li>
+             <li class="locationAvailability">
+              <a href="#">
+               <span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">
+                40. Sham Shui Po
+               </span>
+              </a>
+              <span class="availabilityCount" dir="ltr">
+               (1 available)
+              </span>
+             </li>
+             <li class="locationAvailability">
+              <a href="#">
+               <span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">
+                62. Tsuen Wan
+               </span>
+              </a>
+              <span class="availabilityCount" dir="ltr">
+               (1 available)
+              </span>
+             </li>
+             <li class="locationAvailability">
+              <a href="#">
+               <span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">
+                68. Yau Ma Tei
+               </span>
+              </a>
+              <span class="availabilityCount" dir="ltr">
+               (1 available)
+              </span>
+             </li>
+             <li class="locationAvailability">
+              <a href="#">
+               <span class="availabilityLocation" dir="ltr" onclick="var win = this.ownerDocument.defaultView || this.ownerDocument.parentWindow; if (win == window) { window.location.href='../lib/item?id=chamo:3677805&amp;fromLocationLink=true&amp;theme=WEB'; } ;return false">
+                70. Yuen Chau Kok
+               </span>
+              </a>
+              <span class="availabilityCount" dir="ltr">
+               (1 available)
+              </span>
+             </li>
+            </ul>
+            <script type="text/javascript">
+             /*<![CDATA[*/
+showMoreInitialize($('#id22'), 3, 'Show less...', 'Show more...');
+
+/*]]>*/
+            </script>
+           </div>
+           <div class="request-item">
+            <span class="requestCount" dir="ltr">
+             0 reservation made for this item.
+            </span>
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-9-searchRecord-requestItem-requestButton&amp;theme=WEB&amp;locale=en">
+             Reserve
+            </a>
+           </div>
+           <div class="recordCart">
+            <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-searchResults-9-searchRecord-recordCart-addToCart&amp;theme=WEB" id="idb">
+             Add To Cart
+            </a>
+            <a id="id23" style="display:none">
+            </a>
+           </div>
+          </div>
+          <div class="recordSeparator">
+          </div>
+         </li>
+        </ul>
+        <div>
+         <div class="buttons">
+          <a class="button" href="../wicket/page?0-1.ILinkListener-results-resultListForm-listItems-bottomCartButtons-addToCart&amp;theme=WEB" id="idc">
+           Select Page
+          </a>
+         </div>
+        </div>
+       </span>
+      </form>
+      <div class="bottomNavBar">
+       <div class="pageLinks">
+        <span>
+         <span>
+          1
+         </span>
+        </span>
+        <span>
+         |
+        </span>
+        <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=2&amp;theme=WEB">
+         <span>
+          2
+         </span>
+        </a>
+        <span>
+         |
+        </span>
+        <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=3&amp;theme=WEB">
+         <span>
+          3
+         </span>
+        </a>
+        <span>
+         |
+        </span>
+        <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=4&amp;theme=WEB">
+         <span>
+          4
+         </span>
+        </a>
+        <span>
+         |
+        </span>
+        <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;sort=relevance&amp;pageNumber=2&amp;theme=WEB">
+         <span>
+          Next &gt;
+         </span>
+        </a>
+       </div>
+       <div>
+        <label for="search-pagesize">
+         Results per page
+        </label>
+        <select class="inline select" id="search-pagesize" name="results:pageSizeSelector:search-pagesize" onchange="window.location.href='../wicket/page?0-1.IOnChangeListener-results-pageSizeSelector-search~pagesize&amp;theme=WEB&amp;results:pageSizeSelector:search-pagesize=' + this.options[this.selectedIndex].value;">
+         <option value="5">
+          5
+         </option>
+         <option selected="selected" value="10">
+          10
+         </option>
+         <option value="20">
+          20
+         </option>
+         <option value="30">
+          30
+         </option>
+         <option value="40">
+          40
+         </option>
+         <option value="50">
+          50
+         </option>
+        </select>
+       </div>
+      </div>
+     </div>
+     <div class="sidebar" id="refine">
+      <div class="header">
+       Refine your search
+      </div>
+      <div id="additional-search-terms">
+       <form action="../wicket/page?0-1.IFormSubmitListener-facets-additionalTermsForm&amp;theme=WEB" id="id24" method="post">
+        <div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden">
+         <input id="id24_hf_0" name="id24_hf_0" type="hidden"/>
+        </div>
+        <div>
+         <label for="additional-terms">
+          Additional Terms
+         </label>
+         <input id="additional-terms" maxlength="250" name="additionalTerms" type="text" value=""/>
+         <input class="button" id="add-additional-terms" type="submit" value="Add"/>
+        </div>
+       </form>
+      </div>
+      <ul>
+       <li>
+        <span class="facetField" dir="ltr">
+         Publication Year
+        </span>
+        <ul id="id25">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.202&amp;sort=relevance&amp;theme=WEB">
+           2020 - 2029
+          </a>
+          (
+          <span class="facetCount">
+           58
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.201&amp;sort=relevance&amp;theme=WEB">
+           2010 - 2019
+          </a>
+          (
+          <span class="facetCount">
+           211
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.200&amp;sort=relevance&amp;theme=WEB">
+           2000 - 2009
+          </a>
+          (
+          <span class="facetCount">
+           418
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.199&amp;sort=relevance&amp;theme=WEB">
+           1990 - 1999
+          </a>
+          (
+          <span class="facetCount">
+           336
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.198&amp;sort=relevance&amp;theme=WEB">
+           1980 - 1989
+          </a>
+          (
+          <span class="facetCount">
+           124
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.197&amp;sort=relevance&amp;theme=WEB">
+           1970 - 1979
+          </a>
+          (
+          <span class="facetCount">
+           69
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.196&amp;sort=relevance&amp;theme=WEB">
+           1960 - 1969
+          </a>
+          (
+          <span class="facetCount">
+           53
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.195&amp;sort=relevance&amp;theme=WEB">
+           1950 - 1959
+          </a>
+          (
+          <span class="facetCount">
+           15
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.194&amp;sort=relevance&amp;theme=WEB">
+           1940 - 1949
+          </a>
+          (
+          <span class="facetCount">
+           3
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.193&amp;sort=relevance&amp;theme=WEB">
+           1930 - 1939
+          </a>
+          (
+          <span class="facetCount">
+           48
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.192&amp;sort=relevance&amp;theme=WEB">
+           1920 - 1929
+          </a>
+          (
+          <span class="facetCount">
+           12
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.191&amp;sort=relevance&amp;theme=WEB">
+           1910 - 1919
+          </a>
+          (
+          <span class="facetCount">
+           6
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.190&amp;sort=relevance&amp;theme=WEB">
+           1900 - 1909
+          </a>
+          (
+          <span class="facetCount">
+           11
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.189&amp;sort=relevance&amp;theme=WEB">
+           1890 - 1899
+          </a>
+          (
+          <span class="facetCount">
+           9
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.188&amp;sort=relevance&amp;theme=WEB">
+           1880 - 1889
+          </a>
+          (
+          <span class="facetCount">
+           5
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.187&amp;sort=relevance&amp;theme=WEB">
+           1870 - 1879
+          </a>
+          (
+          <span class="facetCount">
+           11
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.184&amp;sort=relevance&amp;theme=WEB">
+           1840 - 1849
+          </a>
+          (
+          <span class="facetCount">
+           16
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_date=0.167&amp;sort=relevance&amp;theme=WEB">
+           1670 - 1679
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id25'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+       <li>
+        <span class="facetField" dir="ltr">
+         Language
+        </span>
+        <ul id="id26">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=chi&amp;sort=relevance&amp;theme=WEB">
+           Chinese
+          </a>
+          (
+          <span class="facetCount">
+           1534
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=eng&amp;sort=relevance&amp;theme=WEB">
+           English
+          </a>
+          (
+          <span class="facetCount">
+           5
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=jpn&amp;sort=relevance&amp;theme=WEB">
+           Japanese
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_lang=mul&amp;sort=relevance&amp;theme=WEB">
+           Multiple languages
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id26'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+       <li>
+        <span class="facetField" dir="ltr">
+         Place of Publication
+        </span>
+        <ul id="id27">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=cc&amp;sort=relevance&amp;theme=WEB">
+           China
+          </a>
+          (
+          <span class="facetCount">
+           951
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=ch&amp;sort=relevance&amp;theme=WEB">
+           Taiwan
+          </a>
+          (
+          <span class="facetCount">
+           268
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=cch&amp;sort=relevance&amp;theme=WEB">
+           Hong Kong
+          </a>
+          (
+          <span class="facetCount">
+           217
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=xx&amp;sort=relevance&amp;theme=WEB">
+           No place / unknown
+          </a>
+          (
+          <span class="facetCount">
+           91
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=si&amp;sort=relevance&amp;theme=WEB">
+           Singapore
+          </a>
+          (
+          <span class="facetCount">
+           7
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=bcc&amp;sort=relevance&amp;theme=WEB">
+           British Columbia
+          </a>
+          (
+          <span class="facetCount">
+           4
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=ja&amp;sort=relevance&amp;theme=WEB">
+           Japan
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=dcu&amp;sort=relevance&amp;theme=WEB">
+           District of Columbia
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_pp=my&amp;sort=relevance&amp;theme=WEB">
+           Malaysia
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id27'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+       <li>
+        <span class="facetField" dir="ltr">
+         Library
+        </span>
+        <ul id="id28">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=501000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            01. Aberdeen
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           64
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=701000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            02. Ap Lei Chau
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           23
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=702000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            03. Butterfly Estate
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           12
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=502000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            04. Chai Wan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           86
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=503000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            05. Cheung Chau
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           31
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=301000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            06. City Hall
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           178
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=703000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            07. Electric Road
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           18
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=504000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            08. Fa Yuen Street
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           50
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=505000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            09. Fanling
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           120
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904340000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            10. Fanling South
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           27
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=704000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            11. Fu Shan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           29
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=1000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            12. Hong Kong Central
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           1345
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904090000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            12. Hong Kong Central (Arts Resource Centre)
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           46
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=705000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            13. Hung Hom
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           23
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=302000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            14. Kowloon
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           368
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=706000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            15. Kowloon City
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           25
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=506000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            16. Lai Chi Kok
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           71
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=707000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            17. Lam Tin
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           102
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=708000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            18. Lei Yue Mun
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           29
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=709000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            19. Lek Yuen
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           16
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=507000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            20. Lockhart Road
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           77
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=710000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            21. Lok Fu
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           29
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=711000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            22. Lung Hing
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           17
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=508000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            23. Ma On Shan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           71
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=712000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            24. Mui Wo
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=509000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            25. Ngau Chi Wan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           54
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=510000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            26. Ngau Tau Kok
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           59
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=511000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            27. North Kwai Chung
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           68
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=713000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            28. North Lamma
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           7
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=512000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            29. North Point
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           27
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=715000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            30. Peng Chau
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           5
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904220000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            31. Ping Shan Tin Shui Wai
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           242
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=513000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            32. Po On Road
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           52
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=716000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            33. Pok Fu Lam
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           19
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=514000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            34. Quarry Bay
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           68
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=515000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            35. Sai Kung
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           29
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=516000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            36. San Po Kong
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           76
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=717000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            37. Sau Mau Ping
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           17
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=718000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            38. Sha Tau Kok
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           3
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=303000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            39. Sha Tin
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           196
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904360000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            40. Sham Shui Po
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           56
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=714000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            41. Shek Kip Mei
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           35
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=517000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            42. Shek Tong Tsui
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           67
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=719000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            43. Shek Wai Kok
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           21
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=518000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            44. Sheung Shui
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           79
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=519000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            45. Shui Wo Street
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           70
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=720000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            46. Shun Lee Estate
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           15
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904170000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            47. Siu Sai Wan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           26
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=721000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            48. Smithfield
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           30
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=520000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            49. South Kwai Chung
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           71
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=722000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            50. South Lamma
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=723000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            51. Stanley
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           23
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=521000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            52. Tai Hing
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           35
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=724000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            53. Tai Kok Tsui
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           22
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=725000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            54. Tai O
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           3
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=522000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            55. Tai Po
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           100
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=726000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            56. Tin Shui Wai North
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           19
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904200000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            57. Tiu Keng Leng
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           99
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=524000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            58. To Kwa Wan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           64
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=525000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            59. Tseung Kwan O
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           106
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=727000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            60. Tsim Sha Tsui
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           21
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=526000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            61. Tsing Yi
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           76
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=304000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            62. Tsuen Wan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           254
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=728000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            63. Tsz Wan Shan
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           25
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=305000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            64. Tuen Mun
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           197
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=729000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            65. Tung Chung
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           105
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=730000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            66. Un Chau Street
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           21
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=731000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            67. Wong Nai Chung
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           20
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=527000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            68. Yau Ma Tei
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           45
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=732000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            69. Yiu Tung
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           18
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904300000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            70. Yuen Chau Kok
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           81
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=528000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            71. Yuen Long
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           65
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=901000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            72. Mobile Library 1
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           10
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=902000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            73. Mobile Library 2
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           8
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=903000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            74. Mobile Library 3/10
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           19
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904000000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            75. Mobile Library 4
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           10
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=901020000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            76. Mobile Library 5
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           7
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904040000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            77. Mobile Library 6/9
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           18
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904050000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            78. Mobile Library 7
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           14
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904060000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            79. Mobile Library 8
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           10
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904310000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            80. Mobile Library 11
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           11
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904320000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            81. Mobile Library 12
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           7
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904380000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            82. Self-service Library Station (Island East Sports Centre Sitting-out Area)
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           5
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904400000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            83. Self-service Library Station (Hong Kong Cultural Centre)
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           3
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_loc=904410000&amp;sort=relevance&amp;theme=WEB">
+           <img class="multiselect" src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/checkbox_unselected-ver-A3C8EF2F745EFB9757563B2DBE00941B.png?en-WEB"/>
+           <span class="multiselect-inactive">
+            84. Self-service Library Station (Tsuen Nam Road, Tai Wai)
+           </span>
+          </a>
+          (
+          <span class="facetCount">
+           3
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id28'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+       <li>
+        <span class="facetField" dir="ltr">
+         Format
+        </span>
+        <ul id="id29">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=book&amp;sort=relevance&amp;theme=WEB">
+           Book
+          </a>
+          (
+          <span class="facetCount">
+           1399
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=movies&amp;sort=relevance&amp;theme=WEB">
+           Visual Materials
+          </a>
+          (
+          <span class="facetCount">
+           79
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=sound_recording&amp;sort=relevance&amp;theme=WEB">
+           Sound Recording
+          </a>
+          (
+          <span class="facetCount">
+           54
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=movies.dvd&amp;sort=relevance&amp;theme=WEB">
+           DVD
+          </a>
+          (
+          <span class="facetCount">
+           44
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=sound_recording.audiobook&amp;sort=relevance&amp;theme=WEB">
+           Audio Book
+          </a>
+          (
+          <span class="facetCount">
+           42
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=movies.vhs&amp;sort=relevance&amp;theme=WEB">
+           VHS
+          </a>
+          (
+          <span class="facetCount">
+           34
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=sound_recording.cd&amp;sort=relevance&amp;theme=WEB">
+           CD
+          </a>
+          (
+          <span class="facetCount">
+           7
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=Map&amp;sort=relevance&amp;theme=WEB">
+           Map
+          </a>
+          (
+          <span class="facetCount">
+           4
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=computer_games&amp;sort=relevance&amp;theme=WEB">
+           Computer Software
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_format=serial&amp;sort=relevance&amp;theme=WEB">
+           Serial
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id29'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+       <li>
+        <span class="facetField" dir="ltr">
+         Item Class
+        </span>
+        <ul id="id2a">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=32&amp;sort=relevance&amp;theme=WEB">
+           Reference Materials
+          </a>
+          (
+          <span class="facetCount">
+           1212
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=3&amp;sort=relevance&amp;theme=WEB">
+           Adult Lending Books
+          </a>
+          (
+          <span class="facetCount">
+           613
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=11&amp;sort=relevance&amp;theme=WEB">
+           Junior Lending Books
+          </a>
+          (
+          <span class="facetCount">
+           84
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=19&amp;sort=relevance&amp;theme=WEB">
+           Mobile Adult Lending Books
+          </a>
+          (
+          <span class="facetCount">
+           20
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=26&amp;sort=relevance&amp;theme=WEB">
+           Mobile Junior Lending Books
+          </a>
+          (
+          <span class="facetCount">
+           20
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=7&amp;sort=relevance&amp;theme=WEB">
+           Adult Lending Non-Book Materials
+          </a>
+          (
+          <span class="facetCount">
+           17
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=2&amp;sort=relevance&amp;theme=WEB">
+           Adult Lending Accompanying Materials
+          </a>
+          (
+          <span class="facetCount">
+           5
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=15&amp;sort=relevance&amp;theme=WEB">
+           Junior Lending Non-book Materials
+          </a>
+          (
+          <span class="facetCount">
+           3
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=10&amp;sort=relevance&amp;theme=WEB">
+           Junior Lending Accompanying Materials
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=22&amp;sort=relevance&amp;theme=WEB">
+           Mobile Adult Lending Non-Book Materials
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_item_class=25&amp;sort=relevance&amp;theme=WEB">
+           Mobile Junior Lending Accompanying Materials
+          </a>
+          (
+          <span class="facetCount">
+           1
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id2a'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+       <li>
+        <span class="facetField" dir="ltr">
+         Average Rating
+        </span>
+        <ul id="id2b">
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=5&amp;sort=relevance&amp;theme=WEB">
+           <img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_5-ver-D2BF8E75D0FBAFB8966709BBB65CB79C.png?en-WEB"/>
+          </a>
+          (
+          <span class="facetCount">
+           35
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=4&amp;sort=relevance&amp;theme=WEB">
+           <img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_4-ver-546323FD7198BCCFF3F8E4D1BF5E6B18.png?en-WEB"/>
+          </a>
+          (
+          <span class="facetCount">
+           11
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=3&amp;sort=relevance&amp;theme=WEB">
+           <img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_3-ver-53545B8190EE5E2F4227D38CB81D647D.png?en-WEB"/>
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+         <li>
+          <a href="./query?match_1=MUST&amp;field_1&amp;term_1=%E5%AD%94%E5%AD%90&amp;facet_rating=1&amp;sort=relevance&amp;theme=WEB">
+           <img src="../wicket/resource/com.vtls.chamo.webapp.application.resources.Resources/stars_1-ver-A4817BFA47BE370F3D9A08C59698E035.png?en-WEB"/>
+          </a>
+          (
+          <span class="facetCount">
+           2
+          </span>
+          )
+         </li>
+        </ul>
+        <script type="text/javascript">
+         /*<![CDATA[*/
+showMoreInitialize($('#id2b'), 5, 'Show less...', 'Show more...');
+
+/*]]>*/
+        </script>
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <div class="clearfix" id="footer">
+    <style>
+     /*<![CDATA[*/
+
+#footerLink:hover{
+        color: #FFFF00 !important;
+        background:none !important;
+}
+
+/*]]>*/
+    </style>
+    <div id="divider">
+    </div>
+    <span class="left">
+     <span id="version">
+      Version 3.5
+     </span>
+    </span>
+    <span>
+     <!--<a id="footerLink" href="http://10.47.243.52/misc/ngils/best_view/best_view_en.htm" style="color:white;text-decoration:underline;" onclick="window.open(this.href, '關於圖書館目錄',
+'left=20,top=20,width=800,height=270,toolbar=1,resizable=0'); return false;">-->
+     <!--<a id="footerLink" href="http://cslinux0.comp.hkbu.edu.hk/~e2402184/best_view_en.htm" style="color:white;text-decoration:underline;" 
+			onclick="window.open(this.href, '關於圖書館目錄','left=20,top=20,width=400,height=200,toolbar=1,resizable=0'); return false;">-->
+     <script type="text/javascript">
+      /*<![CDATA[*/
+
+		var url=window.location.toString();
+		var link1="";
+
+		if (url.indexOf("TuniS")!=-1)
+		{
+			link1 = "http://www.hkpl.gov.hk/misc/ngils/best_view_sc.htm";
+		}
+		else
+		{
+			link1 = "http://www.hkpl.gov.hk/misc/ngils/best_view_en.htm";
+		}
+		var finalLink = "<a id=\"footerLink\" href=\""+link1+"\" style=\"color:white;text-decoration:underline;\" "+
+			"onclick=\"window.open(this.href, \'關於圖書館目錄\',\'left=20,top=20,width=400,height=200,toolbar=1,resizable=0\'); return false;\">About Library Catalogue</a>";
+		//document.write(finalLink);
+		
+/*]]>*/
+     </script>
+    </span>
+    <span class="right">
+     © 2008-2011
+     <a>
+      VTLS
+     </a>
+    </span>
+   </div>
+  </div>
+ </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,6 +59,12 @@
         </div>
         <!-- sgisdghl -->
     </header>
+    <form action="/search" method="post">
+        <!-- <a href="/search">Search Books</a> -->
+        <input type="text" name="search_term" placeholder="Enter book title or author">
+        <input type="submit" value="Search">
+    </form>
+
     <form action="/" method="post">
         BIB:
         <input type="text" name="bib" placeholder="e.g. 003377312" onblur="this.value=removeSpaces(this.value);">

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,28 +6,47 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.default.min.css">
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.15.2/css/selectize.default.min.css">
     <style>
-        form {margin: 10px 0px;}
-        table, th, td {border: 1px solid black;}
-        th, td {padding: 3px;}
-        ul:before{
-            content:attr(aria-label);
-            font-size:120%;
-            font-weight:bold;
-            margin-left:-15px;
+        form {
+            margin: 10px 0px;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        th,
+        td {
+            padding: 3px;
+        }
+
+        ul:before {
+            content: attr(aria-label);
+            font-size: 120%;
+            font-weight: bold;
+            margin-left: -15px;
             margin-top: 200px;
         }
+
         .selectize-control {
             display: inline-block;
-            width: 200px;
             margin-left: 10px;
             vertical-align: middle;
+            max-width: calc(100vw - 300px);
+        }
+
+        .selectize-dropdown {
+            width: auto !important;
+            max-width: calc(100vw - 300px);
         }
     </style>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script language="javascript" type="text/javascript">
-        function removeSpaces(string) {return string.split(' ').join('');}
+        function removeSpaces(string) { return string.split(' ').join(''); }
     </script>
 </head>
 
@@ -35,7 +54,8 @@
     <header>
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h1>HKPL Tools</h1>
-            <a href="/user_guide" style="text-decoration: none; font-size: 1.5em; color: #666; margin-right: 10px;">?</a>
+            <a href="/user_guide"
+                style="text-decoration: none; font-size: 1.5em; color: #666; margin-right: 10px;">?</a>
         </div>
         <!-- sgisdghl -->
     </header>
@@ -45,7 +65,7 @@
         <input type="submit" value="Save Book">
         <span>{{save_msg}}</span>
     </form>
-    
+
     <a href="{{('Saved_Books')}}">View Saved Books</a>
 
     <form action="/" method="POST">
@@ -58,10 +78,11 @@
         <select name="library" class="selectize">
             <option value="" disabled selected>Select library</option>
             {%for library in libraries%}
-            <option value="{{library.englishName}}" {% if selection == library.englishName  %} selected {% endif %}>{{library.libraryNumber}}. {{library.englishName}} Library</option>
+            <option value="{{library.englishName}}" {% if selection==library.englishName %} selected {% endif %}>
+                {{library.libraryNumber}}. {{library.englishName}} Library</option>
             {%endfor%}
         </select>
-        <input type="submit" value="Confirm"> 
+        <input type="submit" value="Confirm">
     </form>
 
     <table>
@@ -82,7 +103,7 @@
         {%endfor%}
     </table>
     <span>{{error_msg}}</span>
-    
+
     <ul style="margin-top: 400px;" aria-label="Todo">
         <li>extract getLibraryID function</li>
         <li>add new ssp library</li>
@@ -99,12 +120,46 @@
         <li>handle 0 checkbox submit</li>
         <li>central libray not working (also art one)</li>
         <li>add table to store deleted books</li>
-        
+
     </ul>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.15.2/js/selectize.min.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            $('.selectize').selectize();
+        document.addEventListener('DOMContentLoaded', function () {
+            const select = $('.selectize').selectize({
+                plugins: ["clear_button"]
+            });
+
+            // Calculate width based on longest item
+            const selectize = select[0].selectize;
+            const items = selectize.options;
+            let maxWidth = 0;
+
+            // Create temporary element to measure text width
+            const temp = document.createElement('span');
+            temp.style.visibility = 'hidden';
+            temp.style.whiteSpace = 'nowrap';
+            document.body.appendChild(temp);
+
+            // Find the longest item
+            Object.values(items).forEach(item => {
+                temp.textContent = item.text;
+                maxWidth = Math.max(maxWidth, temp.offsetWidth);
+            });
+
+            // Clean up
+            document.body.removeChild(temp);
+
+            // Set width with max constraint
+            const finalWidth = Math.min(maxWidth + 40, window.innerWidth - 300); // Add padding and respect max width
+            selectize.$control.css('width', finalWidth + 'px');
+            selectize.$dropdown.css('width', finalWidth + 'px');
+
+            // Handle window resize
+            window.addEventListener('resize', () => {
+                const newWidth = Math.min(maxWidth + 40, window.innerWidth - 300);
+                selectize.$control.css('width', newWidth + 'px');
+                selectize.$dropdown.css('width', newWidth + 'px');
+            });
         });
     </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,10 @@
 
 <body>
     <header>
-        <h1>HKPL Tools</h1>
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h1>HKPL Tools</h1>
+            <a href="/user_guide" style="text-decoration: none; font-size: 1.5em; color: #666; margin-right: 10px;">?</a>
+        </div>
         <!-- sgisdghl -->
     </header>
     <form action="/" method="post">

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
         <select name="library" class="selectize">
             <option value="" disabled selected>Select library</option>
             {%for library in libraries%}
-            <option value="{{library}}" {% if selection == library %} selected {% endif %}>{{library}} Library</option>
+            <option value="{{library.englishName}}" {% if selection == library.englishName  %} selected {% endif %}>{{library.libraryNumber}}. {{library.englishName}} Library</option>
             {%endfor%}
         </select>
         <input type="submit" value="Confirm"> 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.default.min.css">
     <style>
         form {margin: 10px 0px;}
         table, th, td {border: 1px solid black;}
@@ -16,11 +17,18 @@
             font-weight:bold;
             margin-left:-15px;
             margin-top: 200px;
-        }  
-        </style>
+        }
+        .selectize-control {
+            display: inline-block;
+            width: 200px;
+            margin-left: 10px;
+            vertical-align: middle;
+        }
+    </style>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script language="javascript" type="text/javascript">
         function removeSpaces(string) {return string.split(' ').join('');}
-        </script>
+    </script>
 </head>
 
 <body>
@@ -47,8 +55,8 @@
 
     <form action="/" method="POST">
         <label style="font-weight: bold;">Check Library</label>
-        <select name="library" >
-            <!-- <option value="" disabled selected>Select your option</option> -->
+        <select name="library" class="selectize">
+            <option value="" disabled selected>Select library</option>
             {%for library in libraries%}
             <option value="{{library}}" {% if selection == library %} selected {% endif %}>{{library}} Library</option>
             {%endfor%}
@@ -93,6 +101,12 @@
         <li>add table to store deleted books</li>
         
     </ul>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            $('.selectize').selectize();
+        });
+    </script>
 </body>
 
 </html>

--- a/templates/search.html
+++ b/templates/search.html
@@ -64,6 +64,9 @@
                 {% endif %}
                 <h3>{{ book.title }}</h3>
                 <p>Publication: {{ book.publication }}</p>
+                {% if book.available_copies %}
+                <p>Available Copies: {{ book.available_copies }}</p>
+                {% endif %}
                 <form action="/" method="POST">
                     <input type="hidden" name="bib" value="{{ book.bib }}">
                     <button class="save-button" type="submit">Save Book</button>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Search Books - HKPL Tools</title>
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.15.2/css/selectize.default.min.css">
+    <style>
+        .search-container {
+            max-width: 800px;
+            margin: 20px auto;
+            padding: 20px;
+        }
+
+        .search-form {
+            margin-bottom: 20px;
+        }
+
+        .search-results {
+            margin-top: 20px;
+        }
+
+        .result-item {
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+        }
+
+        .result-item h3 {
+            margin: 0 0 10px;
+        }
+
+        .save-button {
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="search-container">
+        <h1>Search Books</h1>
+
+        <form class="search-form" action="/search" method="post">
+            <input type="text" name="search_term" placeholder="Enter book title or author" value="{{ search_term }}">
+            <button type="submit">Search</button>
+        </form>
+
+        {% if results %}
+        <div class="search-results">
+            {% for book in results %}
+            <div class="result-item">
+                {% if book.image_url %}
+                <img src="{{ book.image_url }}" alt="{{ book.title }} cover"
+                    style="max-width: 100px; margin-right: 10px;">
+                {% endif %}
+                <h3>{{ book.title }}</h3>
+                <p>Publication: {{ book.publication }}</p>
+                <form action="/" method="POST">
+                    <input type="hidden" name="bib" value="{{ book.bib }}">
+                    <button class="save-button" type="submit">Save Book</button>
+                </form>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <div style="margin-top: 30px;">
+            <a href="/">Back to Home</a>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/templates/user_guide.html
+++ b/templates/user_guide.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HKPL Tools User Guide</title>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; max-width: 800px; margin: 0 auto; padding: 20px; }
+        h1, h2 { color: #2c3e50; }
+        pre { background: #f4f4f4; padding: 10px; border-radius: 5px; overflow-x: auto; }
+        .mermaid { text-align: center; margin: 20px 0; }
+    </style>
+</head>
+<body>
+    <h1>HKPL Tools User Guide</h1>
+    
+    <h2>System Workflow</h2>
+    <div class="mermaid">
+        sequenceDiagram
+            participant User
+            participant WebUI
+            participant Database
+            participant HKPLWebsite
+            
+            User->>WebUI: Enters BIB ID/URL
+            WebUI->>HKPLWebsite: Scrapes book data
+            HKPLWebsite-->>WebUI: Returns book details
+            WebUI->>Database: Stores book metadata
+            WebUI-->>User: Shows save confirmation
+            
+            User->>WebUI: Selects library
+            WebUI->>Database: Queries available copies
+            Database-->>WebUI: Returns availability data
+            WebUI-->>User: Displays library availability
+            
+            User->>WebUI: Clicks "Update Copies"
+            WebUI->>HKPLWebsite: Checks current status
+            HKPLWebsite-->>WebUI: Returns latest data
+            WebUI->>Database: Updates records
+            WebUI-->>User: Shows update status
+            
+            User->>WebUI: Views Saved Books
+            WebUI->>Database: Retrieves tracked books
+            Database-->>WebUI: Returns book list
+            WebUI-->>User: Displays management interface
+    </div>
+
+    <h2>Key Interaction Points</h2>
+    <h3>1. Book Tracking</h3>
+    <ul>
+        <li><strong>Input:</strong> BIB ID or library URL</li>
+        <li><strong>Process:</strong> Web scraping → Database storage</li>
+        <li><strong>Output:</strong> Success/failure message</li>
+    </ul>
+
+    <h3>2. Availability Check</h3>
+    <ul>
+        <li>Select from 20+ HKPL branches</li>
+        <li>Real-time database query</li>
+        <li>Tabular display of available copies</li>
+    </ul>
+
+    <h3>3. Data Maintenance</h3>
+    <ul>
+        <li>Bulk update mechanism</li>
+        <li>Multi-book deletion interface</li>
+        <li>Versioned database updates</li>
+    </ul>
+
+    <h2>Pending Improvements</h2>
+    <ul>
+        <li>Multiple book input support</li>
+        <li>Central library compatibility fixes</li>
+        <li>Enhanced error logging</li>
+        <li>Database connection pooling</li>
+        <li>Soft delete functionality</li>
+    </ul>
+
+    <script>
+        mermaid.initialize({ startOnLoad: true });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
[fix typo](https://github.com/kann4/hkpl_tools/commit/787442b3388ebe09489a32bc80aae9f82cd8623f): beautifulsoup_test --> beautifulsoup

[extract lastupdate template](https://github.com/kann4/hkpl_tools/commit/840727b4bfcc7174f287ec231284991f412c49c6): extract last update text template to remove repetition/duplication

[allow Save Book input to be an URL](https://github.com/kann4/hkpl_tools/commit/a3309dd32cc9b7804ec834e74f38be074aef5fea): originally only allow input as "3745785", now also allow input as full url, eg. "https://webcat.hkpl.gov.hk/lib/item?id=chamo:3745785&fromLocationLink=false&theme=WEB"